### PR TITLE
Sprint2 - Wallet API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/docs/experiment/experiment-jpa-entity-leak.md
+++ b/docs/experiment/experiment-jpa-entity-leak.md
@@ -1,0 +1,153 @@
+# 실험: JPA 엔티티를 Application 경계 밖으로 노출했을 때 발생하는 문제
+
+## 배경
+
+`WalletQueryResult`가 `List<WalletBalance>`를 직접 노출할 때 발생할 수 있는 문제를 검증한다.
+
+---
+
+## 실험 1: LazyInitializationException
+
+### 조건
+- `WalletBalance`의 `wallet` 필드: `@ManyToOne(fetch = FetchType.LAZY)`
+- Controller에서 `WalletBalance.getWallet()` 접근 시도
+
+### 재현 코드
+```java
+// WalletV1Controller.java
+@GetMapping("/{walletId}/balances")
+public ResponseEntity<WalletDto.BalancesResponse> getBalances(@PathVariable UUID walletId) {
+    WalletQueryResult result = walletQueryService.getWalletBalances(walletId);
+
+    // 트랜잭션 종료 후 Lazy 필드 접근 시도
+    result.walletBalances().forEach(wb -> {
+        String walletName = wb.getWallet().getName(); // ← 여기서 터짐
+    });
+    ...
+}
+```
+
+### 예상 결과
+```
+org.hibernate.LazyInitializationException:
+failed to lazily initialize a collection or proxy:
+could not initialize proxy - no Session
+```
+
+### 원인
+`WalletQueryService.getWalletBalances()` 트랜잭션이 종료된 후 Controller에서
+Lazy 프록시에 접근하면 영속성 컨텍스트가 이미 닫혀있어 초기화 불가.
+
+### 실험 결과: 예외가 안 터지는 경우 - OSIV
+
+Spring Boot 기본값이 `spring.jpa.open-in-view=true`이면 예외가 발생하지 않는다.
+OSIV는 HTTP 요청 시작부터 응답까지 Hibernate 세션을 열어두기 때문에
+트랜잭션이 끝나도 Lazy 로딩이 가능하다.
+
+**앱 시작 시 아래 경고가 로그에 출력됨:**
+```
+WARN o.s.b.a.orm.jpa.JpaBaseConfiguration :
+Spring recommends disabling spring.jpa.open-in-view as it initializes a
+lazy loaded JPA entity from outside a transaction.
+```
+
+**OSIV의 문제점:**
+- DB 커넥션을 요청 전체 동안 점유 → 트래픽 많을 때 커넥션 풀 고갈 위험
+- 트랜잭션 밖에서 Lazy 로딩이 되는 의도치 않은 동작
+- 실무에서는 OSIV 끄고 명시적 fetch join 사용 권장
+
+**재현 방법 (OSIV 비활성화):**
+```yaml
+# application-local.yml
+spring:
+  jpa:
+    open-in-view: false
+```
+위 설정 후 재시작하면 `LazyInitializationException` 발생.
+
+---
+
+## 실험 2: 순환 참조 무한루프 (JSON 직렬화)
+
+### 조건
+- `WalletBalance` → `Wallet` (ManyToOne)
+- `Wallet` → `List<WalletBalance>` (OneToMany)
+- Jackson이 `WalletBalance`를 직렬화 시도
+
+### 재현 코드
+```java
+// WalletQueryResult에서 WalletBalance를 그대로 응답에 포함
+public record BalancesResponse(
+    UUID walletId,
+    List<WalletBalance> balances  // ← 엔티티 직접 노출
+) {}
+```
+
+### 예상 결과
+```
+com.fasterxml.jackson.databind.exc.InvalidDefinitionException:
+No serializer found for class org.hibernate.proxy.HibernateProxy
+또는 StackOverflowError (순환 참조)
+```
+
+### 원인
+`WalletBalance` → `Wallet` → `List<WalletBalance>` → `Wallet` → ... 무한 순환.
+
+---
+
+## 실험 3: 의도치 않은 내부 필드 노출
+
+### 조건
+- `WalletBalance`에 `@Version private Long version` 필드 존재
+- API 응답에 그대로 포함
+
+### 예상 결과
+```json
+{
+  "currency": "KRW",
+  "balance": 50000.0000,
+  "version": 3,          ← 내부 낙관적 락 정보 노출
+  "wallet": { ... }      ← 연관 엔티티 전체 노출
+}
+```
+
+### 원인
+DTO 변환 없이 엔티티를 직렬화하면 모든 필드가 노출된다.
+클라이언트가 알 필요 없는 내부 구현 정보까지 포함.
+
+---
+
+## 해결책
+
+`WalletQueryResult`에서 엔티티를 VO(Money)로 변환 후 노출:
+
+```java
+public record WalletQueryResult(
+        UUID walletId,
+        List<Money> balances  // WalletBalance → Money 변환
+) {
+    public static WalletQueryResult of(UUID walletId, List<WalletBalance> walletBalances) {
+        return new WalletQueryResult(
+                walletId,
+                walletBalances.stream().map(WalletBalance::toMoney).toList()
+        );
+    }
+}
+```
+
+- Lazy 로딩 문제 없음 (`Money`는 단순 record)
+- 순환 참조 없음
+- 노출 필드 제어 가능
+
+---
+
+## 결론
+
+| 문제 | 발생 조건 | 심각도 |
+|------|----------|--------|
+| LazyInitializationException | 트랜잭션 밖에서 Lazy 필드 접근 (OSIV=false 조건) | 런타임 에러 |
+| 순환 참조 StackOverflow | 양방향 연관관계 직렬화 | 런타임 에러 |
+| 내부 필드 노출 | DTO 변환 없이 직렬화 | 보안/설계 문제 |
+
+JPA 엔티티는 영속성 컨텍스트 안에서만 다루고,
+Application 경계 밖으로는 VO 또는 전용 Result 객체로 변환해서 전달한다.

--- a/docs/sequenceDiagrams/01-ChargeUseCase.mermaid
+++ b/docs/sequenceDiagrams/01-ChargeUseCase.mermaid
@@ -1,0 +1,58 @@
+sequenceDiagram
+    actor C as Client
+    participant WC as WalletV1Controller
+    participant S as ChargeService
+    participant WS as WalletService
+    participant WBS as WalletBalanceService
+    participant WB as WalletBalance
+    participant L as LedgerEntryRepo
+
+    C ->> WC: 원화 충전 요청
+    activate WC
+        WC ->>S:  charge(walletId, KRW, money)
+        activate S
+            S ->> WS: getWallet(walletId)
+            activate WS
+                alt [wallet 존재]
+                    WS -->> S: wallet 반환
+                else [wallet 없음]
+                    WS -->> S: ERR wallet 없음
+                    S -->> WC: 예외 전파
+                    WC-->> C: HTTP 404 응답
+                end
+            deactivate WS
+
+            note over S: wallet 충전 가능 상태 검증
+            S ->> S: wallet.validateChargeable()
+
+
+            S ->> WBS: getWalletBalance(walletId, KRW)
+            activate WBS
+                alt [walletBalance 존재]
+                    WBS -->> S: walletBalance 반환
+                else [walletBalance 없음]
+                    WBS -->> S: ERR walletBalance 없음
+                    S -->> WC: 예외 전파
+                    WC -->> C: HTTP 404 응답
+                end
+            deactivate WBS
+
+            note over S: 충전 정책 확인 후 지갑 잔액 충전
+            S ->> S: validateKrwCharge(money)
+            S ->> WB: increase(money)
+            activate WB
+                WB  -->> S: 잔액 증가 완료
+            deactivate WB
+
+           note over S: 충전에 대한 원장 기록
+           S ->> S: LedgerEntry.of(walletId, money, balanceAfter, CHARGE)
+           S ->> L: 원장 기록
+           activate L
+                L-->>S: insert 완료
+           deactivate L
+
+           S -->> WC: ChargeResponse
+           deactivate S
+
+           WC -->> C: HTTP 200 OK
+           deactivate WC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+### Library versions ###
+springDocOpenApiVersion=2.8.6

--- a/src/main/java/com/lemonpay/common/config/LocalDataInitializerConfig.java
+++ b/src/main/java/com/lemonpay/common/config/LocalDataInitializerConfig.java
@@ -46,7 +46,7 @@ public class LocalDataInitializerConfig {
             String suffix = String.format("%04d", i);
             String email = "test" + suffix + "@lemonpay.com";
             String name = "test" + suffix;
-            String phone = "test" + suffix;
+            String phone = "+82101234" + suffix;
 
             Member member = Member.create(email, name,phone);
             memberRepository.save(member);

--- a/src/main/java/com/lemonpay/common/exception/CoreException.java
+++ b/src/main/java/com/lemonpay/common/exception/CoreException.java
@@ -1,0 +1,19 @@
+package com.lemonpay.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CoreException extends RuntimeException {
+    private final ErrorType errorType;
+    private final String customMessage;
+
+    public CoreException(ErrorType errorType) {
+        this(errorType, null);
+    }
+
+    public CoreException(ErrorType errorType, String customMessage) {
+        super(customMessage != null ? customMessage : errorType.getMessage());
+        this.errorType = errorType;
+        this.customMessage = customMessage;
+    }
+}

--- a/src/main/java/com/lemonpay/common/exception/ErrorType.java
+++ b/src/main/java/com/lemonpay/common/exception/ErrorType.java
@@ -12,7 +12,7 @@ public enum ErrorType {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_CURRENCY(HttpStatus.BAD_REQUEST, "지원하지 않는 통화입니다."),
     INVALID_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, "충전 금액이 정책 범위를 벗어났습니다."),
-    WALLET_NOT_FOUND(HttpStatus.BAD_REQUEST, "지갑을 찾을 수 없습니다."),
+    WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "지갑을 찾을 수 없습니다."),
 
     // 422
     WALLET_NOT_CHARGEABLE(HttpStatus.UNPROCESSABLE_ENTITY, "충전이 불가능한 지갑 상태입니다."),

--- a/src/main/java/com/lemonpay/common/exception/ErrorType.java
+++ b/src/main/java/com/lemonpay/common/exception/ErrorType.java
@@ -1,0 +1,27 @@
+package com.lemonpay.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+
+    // 4xx
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_CURRENCY(HttpStatus.BAD_REQUEST, "지원하지 않는 통화입니다."),
+    INVALID_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, "충전 금액이 정책 범위를 벗어났습니다."),
+    WALLET_NOT_FOUND(HttpStatus.BAD_REQUEST, "지갑을 찾을 수 없습니다."),
+
+    // 422
+    WALLET_NOT_CHARGEABLE(HttpStatus.UNPROCESSABLE_ENTITY, "충전이 불가능한 지갑 상태입니다."),
+    INVALID_WALLET_STATE_TRANSITION(HttpStatus.UNPROCESSABLE_ENTITY, "허용되지 않는 상태 전이입니다."),
+
+    // 5xx
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/lemonpay/common/interfaces/ErrorResponse.java
+++ b/src/main/java/com/lemonpay/common/interfaces/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.lemonpay.common.interfaces;
+
+import com.lemonpay.common.exception.ErrorType;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+    public static ErrorResponse of(ErrorType errorType) {
+        return new ErrorResponse(errorType.name(), errorType.getMessage());
+    }
+
+    public static ErrorResponse of(ErrorType errorType, String detail) {
+        return new ErrorResponse(errorType.name(), detail);
+    }
+}

--- a/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
+++ b/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.lemonpay.common.interfaces;
+
+import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.common.exception.CoreException;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CoreException.class)
+    public ResponseEntity<ErrorResponse> handleCoreException(CoreException e) {
+        log.warn("CoreException: {}", e.getMessage());
+        ErrorType errorType = e.getErrorType();
+        return ResponseEntity
+                .status(errorType.getStatus())
+                .body(ErrorResponse.of(errorType, e.getMessage()));
+    }
+
+    /** @Valid 검증 실패 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        String detail = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        log.warn("Validation failed: {}", detail);
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail));
+    }
+
+    /** PathVariable/RequestParam 타입 불일치 (e.g. UUID 형식 오류) */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        String detail = "'%s' 파라미터의 값이 올바르지 않습니다.".formatted(e.getName());
+        log.warn("Type mismatch: {}", detail);
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail));
+    }
+
+    /** JSON 파싱 오류 */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadable: {}", e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, "요청 본문을 읽을 수 없습니다."));
+    }
+
+    /** 예상하지 못한 예외 */
+    @ExceptionHandler(Throwable.class)
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(Throwable e) {
+        log.error("Unexpected error", e);
+        return ResponseEntity
+                .internalServerError()
+                .body(ErrorResponse.of(ErrorType.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
+++ b/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
@@ -1,10 +1,8 @@
 package com.lemonpay.common.interfaces;
 
-import com.lemonpay.common.exception.ErrorType;
 import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;

--- a/src/main/java/com/lemonpay/config/OpenApiConfig.java
+++ b/src/main/java/com/lemonpay/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.lemonpay.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("LemonPay API")
+                        .version("v1")
+                        .description("LemonPay API DOCS")
+                );
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/application/ChargeResult.java
+++ b/src/main/java/com/lemonpay/wallet/application/ChargeResult.java
@@ -1,0 +1,16 @@
+package com.lemonpay.wallet.application;
+
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.wallet.domain.WalletBalance;
+
+import java.util.UUID;
+
+public record ChargeResult(
+        UUID walletId,
+        Money chargeMoney,
+        WalletBalance afterWalletBalance
+) {
+    public static ChargeResult of(UUID walletId, Money money, WalletBalance afterWalletBalance) {
+        return new ChargeResult(walletId, money, afterWalletBalance);
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/application/ChargeResult.java
+++ b/src/main/java/com/lemonpay/wallet/application/ChargeResult.java
@@ -8,9 +8,9 @@ import java.util.UUID;
 public record ChargeResult(
         UUID walletId,
         Money chargeMoney,
-        WalletBalance afterWalletBalance
+        Money afterBalance
 ) {
     public static ChargeResult of(UUID walletId, Money money, WalletBalance afterWalletBalance) {
-        return new ChargeResult(walletId, money, afterWalletBalance);
+        return new ChargeResult(walletId, money, afterWalletBalance.toMoney());
     }
 }

--- a/src/main/java/com/lemonpay/wallet/application/ChargeUseCase.java
+++ b/src/main/java/com/lemonpay/wallet/application/ChargeUseCase.java
@@ -1,0 +1,69 @@
+package com.lemonpay.wallet.application;
+
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.ledger.domain.EntryType;
+import com.lemonpay.ledger.domain.LedgerEntry;
+import com.lemonpay.ledger.domain.LedgerEntryRepository;
+import com.lemonpay.wallet.domain.Wallet;
+import com.lemonpay.wallet.domain.WalletBalance;
+import com.lemonpay.wallet.domain.WalletBalanceService;
+import com.lemonpay.wallet.domain.WalletService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChargeUseCase {
+
+   private final WalletService walletService;
+   private final WalletBalanceService walletBalanceService;
+   private final LedgerEntryRepository ledgerEntryRepository;
+
+   private static final BigDecimal MIN_KRW_CHARGE_AMOUNT = BigDecimal.valueOf(1_000);
+   private static final BigDecimal MAX_KRW_CHARGE_AMOUNT = BigDecimal.valueOf(1_000_000);
+
+   @Transactional
+   public ChargeResult charge(UUID walletId, Currency currency, Money money) {
+       Wallet wallet = walletService.getWallet(walletId);
+       wallet.validateChargeable();
+       validateKrwCharge(money);
+
+       WalletBalance walletBalance = walletBalanceService.getWalletBalance(walletId, currency);
+       walletBalance.increase(money);
+
+       Money balanceAfter = walletBalance.toMoney();
+       LedgerEntry ledgerEntry = LedgerEntry.of(walletId, money, balanceAfter, EntryType.CHARGE);
+       ledgerEntryRepository.save(ledgerEntry);
+
+       return ChargeResult.of(walletId, money, walletBalance);
+   }
+
+
+    /**
+     * 충전 금액에 대한 정책을 검증한다.
+     *
+     * <p>현재는 ChargeUseCase 내부에서만 사용되는 단순 정책이므로 private 메소드로 유지한다.
+     * 다통화 충전, 정책 변경(최소/최대 금액, 통화별 규칙 등)으로 재사용 필요성이 생기면,
+     * 별도의 ChargePolicy 클래스로 분리한다. </p>
+     * @param money
+     */
+    private void validateKrwCharge(Money money) {
+        if(money.currency() != Currency.KRW) {
+            throw new IllegalArgumentException("Invalid currency");
+        }
+
+        if(money.amount().compareTo(MIN_KRW_CHARGE_AMOUNT) < 0) {
+            throw new IllegalArgumentException("Invalid amount: " + money.amount());
+        }
+
+        if(money.amount().compareTo(MAX_KRW_CHARGE_AMOUNT) > 0) {
+            throw new IllegalArgumentException("Invalid amount: " + money.amount());
+        }
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/application/ChargeUseCase.java
+++ b/src/main/java/com/lemonpay/wallet/application/ChargeUseCase.java
@@ -31,7 +31,8 @@ public class ChargeUseCase {
    private static final BigDecimal MAX_KRW_CHARGE_AMOUNT = BigDecimal.valueOf(1_000_000);
 
    @Transactional
-   public ChargeResult charge(UUID walletId, Currency currency, Money money) {
+   public ChargeResult charge(UUID walletId, Money money) {
+       Currency currency = money.currency();
        Wallet wallet = walletService.getWallet(walletId);
        wallet.validateChargeable();
        validateKrwCharge(money);

--- a/src/main/java/com/lemonpay/wallet/application/ChargeUseCase.java
+++ b/src/main/java/com/lemonpay/wallet/application/ChargeUseCase.java
@@ -3,6 +3,8 @@ package com.lemonpay.wallet.application;
 
 import com.lemonpay.common.domain.Currency;
 import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
 import com.lemonpay.ledger.domain.EntryType;
 import com.lemonpay.ledger.domain.LedgerEntry;
 import com.lemonpay.ledger.domain.LedgerEntryRepository;
@@ -55,15 +57,17 @@ public class ChargeUseCase {
      */
     private void validateKrwCharge(Money money) {
         if(money.currency() != Currency.KRW) {
-            throw new IllegalArgumentException("Invalid currency");
+            throw new CoreException(ErrorType.INVALID_CURRENCY);
         }
 
         if(money.amount().compareTo(MIN_KRW_CHARGE_AMOUNT) < 0) {
-            throw new IllegalArgumentException("Invalid amount: " + money.amount());
+            throw new CoreException(ErrorType.INVALID_CHARGE_AMOUNT,
+                    "최소 충전 금액은 %s원입니다.".formatted(MIN_KRW_CHARGE_AMOUNT.toPlainString()));
         }
 
         if(money.amount().compareTo(MAX_KRW_CHARGE_AMOUNT) > 0) {
-            throw new IllegalArgumentException("Invalid amount: " + money.amount());
+            throw new CoreException(ErrorType.INVALID_CHARGE_AMOUNT,
+                    "최대 충전 금액은 %s원입니다.".formatted(MAX_KRW_CHARGE_AMOUNT.toPlainString()));
         }
     }
 }

--- a/src/main/java/com/lemonpay/wallet/application/WalletQueryResult.java
+++ b/src/main/java/com/lemonpay/wallet/application/WalletQueryResult.java
@@ -1,0 +1,17 @@
+package com.lemonpay.wallet.application;
+
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.wallet.domain.WalletBalance;
+
+import java.util.List;
+import java.util.UUID;
+
+public record WalletQueryResult(
+        UUID walletId,
+        List<Money> walletBalances
+) {
+    public static WalletQueryResult of(UUID walletId, List<WalletBalance> walletBalances) {
+        var list = walletBalances.stream().map(WalletBalance::toMoney).toList();
+        return new WalletQueryResult(walletId, list);
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/application/WalletQueryService.java
+++ b/src/main/java/com/lemonpay/wallet/application/WalletQueryService.java
@@ -1,0 +1,21 @@
+package com.lemonpay.wallet.application;
+
+import com.lemonpay.wallet.domain.WalletBalanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class WalletQueryService {
+
+    private final WalletBalanceService walletBalanceService;
+
+    @Transactional(readOnly = true)
+    public WalletQueryResult getWalletBalances(UUID walletId) {
+        var walletBalances = walletBalanceService.getWalletBalances(walletId);
+        return WalletQueryResult.of(walletId, walletBalances);
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/domain/Wallet.java
+++ b/src/main/java/com/lemonpay/wallet/domain/Wallet.java
@@ -91,4 +91,10 @@ public class Wallet extends BaseEntity {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("미지원 통화이거나 현재 지갑에 해당 통화 잔액이 없습니다. 현재 통화" + currency));
     }
+
+    public void validateChargeable() {
+        if(status == WalletStatus.CLOSED) {
+            throw new IllegalStateException("충전이 불가능한 상태입니다.");
+        }
+    }
 }

--- a/src/main/java/com/lemonpay/wallet/domain/Wallet.java
+++ b/src/main/java/com/lemonpay/wallet/domain/Wallet.java
@@ -2,6 +2,8 @@ package com.lemonpay.wallet.domain;
 
 import com.lemonpay.common.domain.BaseEntity;
 import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
 import com.lemonpay.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -89,12 +91,12 @@ public class Wallet extends BaseEntity {
         return balances.stream()
                 .filter(b -> b.getCurrency() == currency)
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("미지원 통화이거나 현재 지갑에 해당 통화 잔액이 없습니다. 현재 통화" + currency));
+                .orElseThrow(() -> new CoreException(ErrorType.INVALID_CURRENCY));
     }
 
     public void validateChargeable() {
         if(status == WalletStatus.CLOSED) {
-            throw new IllegalStateException("충전이 불가능한 상태입니다.");
+            throw new CoreException(ErrorType.WALLET_NOT_CHARGEABLE);
         }
     }
 }

--- a/src/main/java/com/lemonpay/wallet/domain/WalletBalanceService.java
+++ b/src/main/java/com/lemonpay/wallet/domain/WalletBalanceService.java
@@ -1,0 +1,37 @@
+package com.lemonpay.wallet.domain;
+
+import com.lemonpay.common.domain.Currency;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class WalletBalanceService {
+
+    private final WalletBalanceRepository walletBalanceRepository;
+
+    @Transactional(readOnly = true)
+    public WalletBalance getWalletBalance(UUID walletId, Currency currency) {
+        return walletBalanceRepository.findByWalletIdAndCurrency(walletId, currency)
+                .orElseThrow(() -> new RuntimeException("Wallet not found"));
+    }
+
+    @Transactional
+    public WalletBalance updateWalletBalance(WalletBalance walletBalance) {
+        return walletBalanceRepository.save(walletBalance);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WalletBalance> getWalletBalances(UUID walletId) {
+        List<WalletBalance> walletBalances = walletBalanceRepository.findAllByWalletId(walletId);
+        if (walletBalances.isEmpty()) {
+            throw new RuntimeException("Wallet not found");
+        }
+        return walletBalances;
+    }
+
+}

--- a/src/main/java/com/lemonpay/wallet/domain/WalletBalanceService.java
+++ b/src/main/java/com/lemonpay/wallet/domain/WalletBalanceService.java
@@ -1,6 +1,8 @@
 package com.lemonpay.wallet.domain;
 
 import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +19,7 @@ public class WalletBalanceService {
     @Transactional(readOnly = true)
     public WalletBalance getWalletBalance(UUID walletId, Currency currency) {
         return walletBalanceRepository.findByWalletIdAndCurrency(walletId, currency)
-                .orElseThrow(() -> new RuntimeException("Wallet not found"));
+                .orElseThrow(() -> new CoreException(ErrorType.WALLET_NOT_FOUND));
     }
 
     @Transactional
@@ -29,7 +31,7 @@ public class WalletBalanceService {
     public List<WalletBalance> getWalletBalances(UUID walletId) {
         List<WalletBalance> walletBalances = walletBalanceRepository.findAllByWalletId(walletId);
         if (walletBalances.isEmpty()) {
-            throw new RuntimeException("Wallet not found");
+            throw new CoreException(ErrorType.WALLET_NOT_FOUND);
         }
         return walletBalances;
     }

--- a/src/main/java/com/lemonpay/wallet/domain/WalletService.java
+++ b/src/main/java/com/lemonpay/wallet/domain/WalletService.java
@@ -1,5 +1,7 @@
 package com.lemonpay.wallet.domain;
 
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +14,6 @@ public class WalletService {
 
     public Wallet getWallet(UUID walletId) {
         return walletRepository.findById(walletId)
-                .orElseThrow(() -> new IllegalArgumentException("Wallet not found"));
+                .orElseThrow(() -> new CoreException(ErrorType.WALLET_NOT_FOUND));
     }
 }

--- a/src/main/java/com/lemonpay/wallet/domain/WalletService.java
+++ b/src/main/java/com/lemonpay/wallet/domain/WalletService.java
@@ -1,0 +1,17 @@
+package com.lemonpay.wallet.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class WalletService {
+    private final WalletRepository walletRepository;
+
+    public Wallet getWallet(UUID walletId) {
+        return walletRepository.findById(walletId)
+                .orElseThrow(() -> new IllegalArgumentException("Wallet not found"));
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/domain/WalletStatus.java
+++ b/src/main/java/com/lemonpay/wallet/domain/WalletStatus.java
@@ -1,5 +1,8 @@
 package com.lemonpay.wallet.domain;
 
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -31,7 +34,8 @@ public enum WalletStatus {
 
     public void validateTransition(WalletStatus next) {
         if(!canTransitionTo(next)) {
-            throw new IllegalStateException(
+            throw new CoreException(
+                    ErrorType.INVALID_WALLET_STATE_TRANSITION,
                     "지갑 상태 전이 불가: %s -> %s".formatted(this.name(), next.name()));
         }
     }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
@@ -1,8 +1,8 @@
 package com.lemonpay.wallet.interfaces.api;
 
+import com.lemonpay.common.domain.Money;
 import com.lemonpay.wallet.application.ChargeResult;
-import com.lemonpay.wallet.domain.Wallet;
-import com.lemonpay.wallet.domain.WalletBalance;
+import com.lemonpay.wallet.application.WalletQueryResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -47,7 +47,7 @@ public class WalletDto {
                     chargeResult.walletId(),
                     chargeResult.chargeMoney().currency().toString(),
                     chargeResult.chargeMoney().amount(),
-                    WalletBalanceItem.from(chargeResult.afterWalletBalance())
+                    WalletBalanceItem.from(chargeResult.afterBalance())
             );
         }
 
@@ -58,19 +58,30 @@ public class WalletDto {
             @Schema(description = "지갑 ID", example = "550e8400-e29b-41d4-a716-446655440000")
             UUID walletId,
 
-            @Schema(description = "충전 후 다통화 잔액 정보")
+            @Schema(description = "현재 다통화 잔액 정보")
             List<WalletBalanceItem> balances
-    ) { }
+    ) {
+        public static BalancesResponse from(WalletQueryResult walletQueryResult) {
+            var balances = walletQueryResult.walletBalances()
+                    .stream().map(WalletBalanceItem::from)
+                    .toList();
+
+            return new BalancesResponse(
+                    walletQueryResult.walletId(),
+                    balances
+            );
+        }
+    }
 
     @Schema(description = "지갑 내 단일 통화 잔액 정보")
     public record WalletBalanceItem(
             String currency,
             BigDecimal amount
     ) {
-        public static WalletBalanceItem from(WalletBalance walletBalance) {
+        public static WalletBalanceItem from(Money money) {
             return new WalletBalanceItem(
-                    walletBalance.getCurrency().toString(),
-                    walletBalance.getBalance()
+                    money.currency().toString(),
+                    money.amount()
             );
         }
     }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
@@ -1,5 +1,8 @@
 package com.lemonpay.wallet.interfaces.api;
 
+import com.lemonpay.wallet.application.ChargeResult;
+import com.lemonpay.wallet.domain.Wallet;
+import com.lemonpay.wallet.domain.WalletBalance;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -38,7 +41,17 @@ public class WalletDto {
 
             @Schema(description = "충전 후 잔액 정보")
             WalletBalanceItem balance
-    ) { }
+    ) {
+        public static ChargeResponse from(ChargeResult chargeResult) {
+            return new ChargeResponse(
+                    chargeResult.walletId(),
+                    chargeResult.chargeMoney().currency().toString(),
+                    chargeResult.chargeMoney().amount(),
+                    WalletBalanceItem.from(chargeResult.afterWalletBalance())
+            );
+        }
+
+    }
 
     @Schema(description = "잔액 조회 응답 DTO")
     public record BalancesResponse(
@@ -53,6 +66,13 @@ public class WalletDto {
     public record WalletBalanceItem(
             String currency,
             BigDecimal amount
-    ) { }
+    ) {
+        public static WalletBalanceItem from(WalletBalance walletBalance) {
+            return new WalletBalanceItem(
+                    walletBalance.getCurrency().toString(),
+                    walletBalance.getBalance()
+            );
+        }
+    }
 
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
@@ -1,0 +1,58 @@
+package com.lemonpay.wallet.interfaces.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "지갑 충전/잔액 조회 등 API 요청 및 응답에 대한 DTO")
+public class WalletDto {
+
+    @Schema(description = "지갑 충전 요청 DTO")
+    public record ChargeRequest(
+            // TODO: 인증 구현 후 memberId는 JWT에서 추출, walletId는 PathVariable로만 받도록 변경
+            @Schema(description = "회원 ID", example = "650e8400-e29b-41d4-a716-446655440000")
+            @NotNull UUID memberId,
+
+            @Schema(description = "통화코드", example = "KRW")
+            @NotBlank String currency,
+
+            @Schema(description = "금액", example = "1000")
+            @NotNull @Positive BigDecimal amount
+    ) { }
+
+    @Schema(description = "지갑 충전 응답 DTO")
+    public record ChargeResponse(
+            @Schema(description = "지갑 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            UUID walletId,
+
+            @Schema(description = "충전 통화", example = "KRW")
+            String currency,
+
+            @Schema(description = "충전 금액", example = "1000.0000")
+            BigDecimal chargedAmount,
+
+            @Schema(description = "충전 후 잔액 정보")
+            WalletBalanceItem balance
+    ) { }
+
+    @Schema(description = "잔액 조회 응답 DTO")
+    public record BalancesResponse(
+            @Schema(description = "지갑 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            UUID walletId,
+
+            @Schema(description = "충전 후 다통화 잔액 정보")
+            List<WalletBalanceItem> balances
+    ) { }
+
+    @Schema(description = "지갑 내 단일 통화 잔액 정보")
+    public record WalletBalanceItem(
+            String currency,
+            BigDecimal amount
+    ) { }
+
+}

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
@@ -1,31 +1,36 @@
 package com.lemonpay.wallet.interfaces.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.Map;
 import java.util.UUID;
 
 @Tag(name = "Wallet V1 API")
 public interface WalletV1ApiSpec {
 
-    @PostMapping("{walletId}/charge")
+    @PostMapping("/{walletId}/charge")
     @Operation(
             summary = "지갑 충전",
             description = "지갑 충전을 통해 지갑 잔액을 증가 시킵니다."
     )
-    ResponseEntity<Void> charge(@PathVariable UUID walletId,
-                                @RequestBody Map<String, Object> requestBody);
+    ResponseEntity<WalletDto.ChargeResponse> charge(
+            @Parameter(description = "지갑 ID", required = true)
+            @PathVariable("walletId") UUID walletId,
+            @Valid @RequestBody WalletDto.ChargeRequest request);
 
-    @GetMapping("{walletId}/balances")
+    @GetMapping("/{walletId}/balances")
     @Operation(
             summary = "잔액 조회",
             description = "지갑의 현재 잔액을 조회합니다."
     )
-    ResponseEntity<?> getBalances(@PathVariable UUID walletId);
+    ResponseEntity<WalletDto.BalancesResponse> getBalances(
+            @Parameter(description = "지갑 ID", required = true)
+            @PathVariable("walletId") UUID walletId);
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
@@ -1,4 +1,31 @@
 package com.lemonpay.wallet.interfaces.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Tag(name = "Wallet V1 API")
 public interface WalletV1ApiSpec {
+
+    @PostMapping("{walletId}/charge")
+    @Operation(
+            summary = "지갑 충전",
+            description = "지갑 충전을 통해 지갑 잔액을 증가 시킵니다."
+    )
+    ResponseEntity<Void> charge(@PathVariable UUID walletId,
+                                @RequestBody Map<String, Object> requestBody);
+
+    @GetMapping("{walletId}/balances")
+    @Operation(
+            summary = "잔액 조회",
+            description = "지갑의 현재 잔액을 조회합니다."
+    )
+    ResponseEntity<?> getBalances(@PathVariable UUID walletId);
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -12,12 +12,13 @@ import java.util.UUID;
 public class WalletV1Controller implements WalletV1ApiSpec {
 
     @Override
-    public ResponseEntity<Void> charge(UUID walletId, Map<String, Object> requestBody) {
-        return null;
+    public ResponseEntity<WalletDto.ChargeResponse> charge(UUID walletId, WalletDto.ChargeRequest request) {
+        return ResponseEntity.ok(new WalletDto.ChargeResponse(walletId, "KRW", request.amount(), null));
+
     }
 
     @Override
-    public ResponseEntity<?> getBalances(UUID walletId) {
-        return null;
+    public ResponseEntity<WalletDto.BalancesResponse> getBalances(UUID walletId) {
+        return ResponseEntity.ok(new WalletDto.BalancesResponse(walletId, List.of()));
     }
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -3,12 +3,12 @@ package com.lemonpay.wallet.interfaces.api;
 import com.lemonpay.common.domain.Currency;
 import com.lemonpay.common.domain.Money;
 import com.lemonpay.wallet.application.ChargeUseCase;
+import com.lemonpay.wallet.application.WalletQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -17,6 +17,7 @@ import java.util.UUID;
 public class WalletV1Controller implements WalletV1ApiSpec {
 
     private final ChargeUseCase chargeUsecase;
+    private final WalletQueryService walletQueryService;
 
     @Override
     public ResponseEntity<WalletDto.ChargeResponse> charge(UUID walletId, WalletDto.ChargeRequest request) {
@@ -30,6 +31,10 @@ public class WalletV1Controller implements WalletV1ApiSpec {
 
     @Override
     public ResponseEntity<WalletDto.BalancesResponse> getBalances(UUID walletId) {
-        return ResponseEntity.ok(new WalletDto.BalancesResponse(walletId, List.of()));
+        var result = walletQueryService.getWalletBalances(walletId);
+        return ResponseEntity.ok(
+                WalletDto.BalancesResponse.from(result)
+        );
     }
+
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -1,0 +1,23 @@
+package com.lemonpay.wallet.interfaces.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/wallets")
+public class WalletV1Controller implements WalletV1ApiSpec {
+
+    @Override
+    public ResponseEntity<Void> charge(UUID walletId, Map<String, Object> requestBody) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<?> getBalances(UUID walletId) {
+        return null;
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -1,5 +1,9 @@
 package com.lemonpay.wallet.interfaces.api;
 
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.wallet.application.ChargeUseCase;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,12 +13,19 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/wallets")
+@RequiredArgsConstructor
 public class WalletV1Controller implements WalletV1ApiSpec {
+
+    private final ChargeUseCase chargeUsecase;
 
     @Override
     public ResponseEntity<WalletDto.ChargeResponse> charge(UUID walletId, WalletDto.ChargeRequest request) {
-        return ResponseEntity.ok(new WalletDto.ChargeResponse(walletId, "KRW", request.amount(), null));
 
+        Currency currency = Currency.valueOf(request.currency());
+        Money money = Money.of(request.amount(), currency);
+        var result = chargeUsecase.charge(walletId, currency, money);
+
+        return ResponseEntity.ok(WalletDto.ChargeResponse.from(result));
     }
 
     @Override

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -24,7 +24,7 @@ public class WalletV1Controller implements WalletV1ApiSpec {
 
         Currency currency = Currency.valueOf(request.currency());
         Money money = Money.of(request.amount(), currency);
-        var result = chargeUsecase.charge(walletId, currency, money);
+        var result = chargeUsecase.charge(walletId, money);
 
         return ResponseEntity.ok(WalletDto.ChargeResponse.from(result));
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,3 +28,12 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
     org.hibernate.stat: debug
+
+springdoc:
+  use-fqn: true
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   application:
     name: lemonpay
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseTest.java
+++ b/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseTest.java
@@ -1,0 +1,141 @@
+package com.lemonpay.wallet.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.ledger.domain.Direction;
+import com.lemonpay.ledger.domain.EntryType;
+import com.lemonpay.ledger.domain.LedgerEntry;
+import com.lemonpay.ledger.domain.LedgerEntryRepository;
+import com.lemonpay.wallet.domain.Wallet;
+import com.lemonpay.wallet.domain.WalletBalance;
+import com.lemonpay.wallet.domain.WalletBalanceService;
+import com.lemonpay.wallet.domain.WalletService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ChargeUseCaseTest {
+
+    @InjectMocks
+    private ChargeUseCase chargeUsecase;
+
+    @Mock
+    private WalletService walletService;
+    @Mock
+    private WalletBalanceService walletBalanceService;
+    @Mock
+    private LedgerEntryRepository ledgerEntryRepository;
+
+    @DisplayName("지갑 충전 성공 케이스")
+    @Nested
+    class Success {
+
+        @Test
+        @DisplayName("지갑에 KRW 충전시 잔액이 증가되고, 원장에 정상적으로 기록된다.")
+        void chargeKrw_withActiveWallet() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            Money chargeAmount = Money.won(2000);
+
+            Wallet wallet = mock(Wallet.class);
+            WalletBalance walletBalance = WalletBalance.zero(wallet, Currency.KRW);
+
+            willDoNothing().given(wallet).validateChargeable();
+            given(walletService.getWallet(walletId)).willReturn(wallet);
+            given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
+
+            // when
+            chargeUsecase.charge(walletId, Currency.KRW, chargeAmount);
+
+            // then
+            then(wallet).should().validateChargeable();
+            assertThat(walletBalance.getBalance()).isEqualByComparingTo(chargeAmount.amount());
+
+            ArgumentCaptor<LedgerEntry> captor = ArgumentCaptor.forClass(LedgerEntry.class);
+            then(ledgerEntryRepository).should().save(captor.capture());
+            LedgerEntry saved = captor.getValue();
+            assertThat(saved.getAmount()).isEqualByComparingTo(chargeAmount.amount()); // 충전금액
+            assertThat(saved.getBalanceAfter()).isEqualByComparingTo(walletBalance.getBalance()); // 누적잔액
+            assertThat(saved.getEntryType()).isEqualTo(EntryType.CHARGE);
+            assertThat(saved.getDirection()).isEqualTo(Direction.CREDIT);
+            assertThat(saved.getCurrency()).isEqualTo(Currency.KRW);
+        }
+    }
+
+    @DisplayName("지갑 충전 실패 케이스")
+    @Nested
+    class Failure {
+
+        @Test
+        @DisplayName("지갑 상태가 입금 불가능한 상태에서 충전하려는 경우 예외가 발생하며 실패한다.")
+        void chargeKrw_withInvalidWallet() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            Wallet wallet = mock(Wallet.class);
+
+            Money chargeAmount = Money.won(2000);
+            WalletBalance walletBalance = WalletBalance.zero(wallet, Currency.KRW);
+
+            willThrow(IllegalStateException.class).given(wallet).validateChargeable();
+            given(walletService.getWallet(walletId)).willReturn(wallet);
+            // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
+
+            // when & then
+            assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
+                    .isInstanceOf(IllegalStateException.class);
+            then(ledgerEntryRepository).should(never()).save(any());
+
+        }
+
+        @Test
+        @DisplayName("KRW 충전 금액이 최소 충전 금액보다 미만인 경우 예외가 발생하며 실패한다.")
+        void chargeKrw_withLessThanMinimumAmount() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            Wallet wallet = mock(Wallet.class);
+
+            Money chargeAmount = Money.won(100);
+            WalletBalance walletBalance = WalletBalance.zero(wallet, Currency.KRW);
+
+            given(walletService.getWallet(walletId)).willReturn(wallet);
+            // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
+
+            assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            then(ledgerEntryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("KRW 충전 금액이 최대 충전 금액보다 초과된 경우 예외가 발생하며 실패한다.")
+        void chargeKrw_withBiggerThanMaximumAmount() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            Wallet wallet = mock(Wallet.class);
+
+            Money chargeAmount = Money.won(1_000_001);
+            WalletBalance walletBalance = WalletBalance.zero(wallet, Currency.KRW);
+
+            given(walletService.getWallet(walletId)).willReturn(wallet);
+            // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
+
+            assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            then(ledgerEntryRepository).should(never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseTest.java
+++ b/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseTest.java
@@ -2,6 +2,7 @@ package com.lemonpay.wallet.application;
 
 import com.lemonpay.common.domain.Currency;
 import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.ledger.domain.Direction;
 import com.lemonpay.ledger.domain.EntryType;
 import com.lemonpay.ledger.domain.LedgerEntry;
@@ -114,7 +115,7 @@ class ChargeUseCaseTest {
             // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
 
             assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(CoreException.class);
 
             then(ledgerEntryRepository).should(never()).save(any());
         }
@@ -133,7 +134,7 @@ class ChargeUseCaseTest {
             // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
 
             assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(CoreException.class);
 
             then(ledgerEntryRepository).should(never()).save(any());
         }

--- a/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseTest.java
+++ b/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseTest.java
@@ -59,12 +59,39 @@ class ChargeUseCaseTest {
             given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
 
             // when
-            chargeUsecase.charge(walletId, Currency.KRW, chargeAmount);
+            chargeUsecase.charge(walletId, chargeAmount);
 
             // then
             then(wallet).should().validateChargeable();
             assertThat(walletBalance.getBalance()).isEqualByComparingTo(chargeAmount.amount());
 
+            assertLedgerEntry(chargeAmount, walletBalance);
+        }
+
+        @Test
+        @DisplayName("FROZEN 상태인 지갑도 KRW 충전이 가능하며, 원장에 정상적으로 기록된다.")
+        void chargeKrw_withFrozenWallet() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            Money chargeAmount = Money.won(2000);
+
+            Wallet wallet = mock(Wallet.class);
+            WalletBalance walletBalance = WalletBalance.zero(wallet, Currency.KRW);
+            given(walletService.getWallet(walletId)).willReturn(wallet);
+            given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
+
+            // when
+            wallet.freeze();
+            chargeUsecase.charge(walletId, chargeAmount);
+
+            // then
+            then(wallet).should().validateChargeable();
+            assertThat(walletBalance.getBalance()).isEqualByComparingTo(chargeAmount.amount());
+
+            assertLedgerEntry(chargeAmount, walletBalance);
+        }
+
+        private void assertLedgerEntry(Money chargeAmount, WalletBalance walletBalance) {
             ArgumentCaptor<LedgerEntry> captor = ArgumentCaptor.forClass(LedgerEntry.class);
             then(ledgerEntryRepository).should().save(captor.capture());
             LedgerEntry saved = captor.getValue();
@@ -95,7 +122,7 @@ class ChargeUseCaseTest {
             // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
 
             // when & then
-            assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
+            assertThatThrownBy(() -> chargeUsecase.charge(walletId, chargeAmount))
                     .isInstanceOf(IllegalStateException.class);
             then(ledgerEntryRepository).should(never()).save(any());
 
@@ -114,7 +141,7 @@ class ChargeUseCaseTest {
             given(walletService.getWallet(walletId)).willReturn(wallet);
             // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
 
-            assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
+            assertThatThrownBy(() -> chargeUsecase.charge(walletId, chargeAmount))
                     .isInstanceOf(CoreException.class);
 
             then(ledgerEntryRepository).should(never()).save(any());
@@ -133,7 +160,7 @@ class ChargeUseCaseTest {
             given(walletService.getWallet(walletId)).willReturn(wallet);
             // given(walletBalanceService.getWalletBalance(walletId, Currency.KRW)).willReturn(walletBalance);
 
-            assertThatThrownBy(() -> chargeUsecase.charge(walletId, Currency.KRW, chargeAmount))
+            assertThatThrownBy(() -> chargeUsecase.charge(walletId, chargeAmount))
                     .isInstanceOf(CoreException.class);
 
             then(ledgerEntryRepository).should(never()).save(any());

--- a/src/test/java/com/lemonpay/wallet/domain/WalletTest.java
+++ b/src/test/java/com/lemonpay/wallet/domain/WalletTest.java
@@ -143,7 +143,12 @@ class WalletTest {
             );
         }
 
-
+        @Test
+        @DisplayName("FROZEN 된 상태에서 validateChargable 하더라도 예외는 발생하지 않는다.")
+        void validateChargeable_thenSuccess() {
+            wallet.freeze();
+            assertDoesNotThrow(() -> wallet.validateChargeable());
+        }
     }
 
     private Member createTestMember() {

--- a/src/test/java/com/lemonpay/wallet/domain/WalletTest.java
+++ b/src/test/java/com/lemonpay/wallet/domain/WalletTest.java
@@ -2,6 +2,7 @@ package com.lemonpay.wallet.domain;
 
 import com.lemonpay.common.domain.Currency;
 import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -119,14 +120,14 @@ class WalletTest {
         @Test
         @DisplayName("ACTIVE 상태에서 다시 active로 하려고 하면 예외가 발생한다.")
         void activeToActive_throwsException() {
-            assertThrows(IllegalStateException.class, () -> wallet.activate());
+            assertThrows(CoreException.class, () -> wallet.activate());
         }
 
         @Test
         @DisplayName("FROZEN 상태에서 다시 freeze 하려고 하면 예외가 발생한다.")
         void frozenToFrozen_throwsException() {
             wallet.freeze();
-            assertThrows(IllegalStateException.class, () -> wallet.freeze());
+            assertThrows(CoreException.class, () -> wallet.freeze());
         }
 
 
@@ -136,9 +137,9 @@ class WalletTest {
             wallet.close();
 
             assertAll(
-                    () ->assertThrows(IllegalStateException.class, () -> wallet.freeze()),
-                    () -> assertThrows(IllegalStateException.class, () -> wallet.close()),
-                    () -> assertThrows(IllegalStateException.class, () -> wallet.activate())
+                    () ->assertThrows(CoreException.class, () -> wallet.freeze()),
+                    () -> assertThrows(CoreException.class, () -> wallet.close()),
+                    () -> assertThrows(CoreException.class, () -> wallet.activate())
             );
         }
 


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
Wallet API 스펙 버전1을 구현하고, 공통 예외 핸들러를 도입하였습니다.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
- Wallet API 스펙 버전1을 구현 - 잔액 충전 / 잔액 조회 API 
- 도메인 엔티티의 application/interfaces 계층으로 침범되는 부분과 발생가능한 문제점들을 인식/실험 
- 공통 예외 핸들러 도입
- ChargeUseCase 시퀀스 다이어그램 작성

## 설계 결정
- 토이 프로젝트 특성 및 API 스펙에 정의된 내용을 바탕으로 ApiResponse 래퍼 방식 대신 예외 응답을 ResponseEntity<ErrorResponse> 로 통힐하여 HTTP 예외를 반환합니다.
- 도메인 엔티티의 application/interfaces 계층 사용을 VO Money로 변경하였습니다. 추가로 전달 정보 필요시 다른 VO를 고민해봐도 될 것 같습니다.
- ChargeUseCase에 대한 단위테스트를 구현하였습니다. 도메인 객체는 실제 객체로, 그외 의존 하는 서비스들을 Mockito 프레임워크를 사용하여 단위테스트 설계하였습니다.

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- 없음

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- [x] 신규 엔드포인트: 
- POST /api/v1/wallets/{walletId}/charge
- GET  /api/v1/wallets/{walletId}/balance

## 테스트
- [x] 단위 테스트 추가/수정

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과

## 관련 이슈
<!-- Closes #이슈번호 -->
- [x] #17 
- [x] #18 
- [x] #20

