### PR TITLE
Sprint2 - Wallet API 거래내역 조회 기능 추가

### DIFF
--- a/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
+++ b/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.lemonpay.common.interfaces;
 import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.common.exception.ErrorType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -64,5 +65,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .internalServerError()
                 .body(ErrorResponse.of(ErrorType.INTERNAL_SERVER_ERROR));
+    }
+
+    /** 잘못된 sort 필드명이 넘어왔을 때 500 대신 400 반환 */
+    @ExceptionHandler(PropertyReferenceException.class)
+    public ResponseEntity<ErrorResponse> handlePropertyReferenceException(PropertyReferenceException e) {
+        log.warn("Invalid sort field: {}", e.getPropertyName());
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST,
+                        "정렬 기준이 올바르지 않습니다: " + e.getPropertyName()));
     }
 }

--- a/src/main/java/com/lemonpay/wallet/application/LedgerEntryItem.java
+++ b/src/main/java/com/lemonpay/wallet/application/LedgerEntryItem.java
@@ -1,0 +1,31 @@
+package com.lemonpay.wallet.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.ledger.domain.Direction;
+import com.lemonpay.ledger.domain.EntryType;
+import com.lemonpay.ledger.domain.LedgerEntry;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record LedgerEntryItem(
+        Long id,
+        Currency currency,       // domain enum은 그대로 써도 됨
+        BigDecimal amount,
+        Direction direction,
+        EntryType entryType,
+        BigDecimal balanceAfter,
+        LocalDateTime createdAt
+) {
+    public static LedgerEntryItem from(LedgerEntry ledgerEntry) {
+        return new LedgerEntryItem(
+                ledgerEntry.getId(),
+                ledgerEntry.getCurrency(),
+                ledgerEntry.getAmount(),
+                ledgerEntry.getDirection(),
+                ledgerEntry.getEntryType(),
+                ledgerEntry.getBalanceAfter(),
+                ledgerEntry.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/application/WalletQueryService.java
+++ b/src/main/java/com/lemonpay/wallet/application/WalletQueryService.java
@@ -1,7 +1,12 @@
 package com.lemonpay.wallet.application;
 
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.ledger.domain.LedgerEntry;
+import com.lemonpay.ledger.domain.LedgerEntryRepository;
 import com.lemonpay.wallet.domain.WalletBalanceService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,10 +17,27 @@ import java.util.UUID;
 public class WalletQueryService {
 
     private final WalletBalanceService walletBalanceService;
+    private final LedgerEntryRepository ledgerEntryRepository;
 
     @Transactional(readOnly = true)
     public WalletQueryResult getWalletBalances(UUID walletId) {
         var walletBalances = walletBalanceService.getWalletBalances(walletId);
         return WalletQueryResult.of(walletId, walletBalances);
     }
+
+    @Transactional(readOnly = true)
+    public Page<LedgerEntryItem> queryLedgerEntries(
+            UUID walletId, Currency currency, Pageable pageable
+    ) {
+        Page<LedgerEntry> result;
+        if (currency == null) {
+            result = ledgerEntryRepository.findByWalletIdOrderByIdDesc(walletId, pageable);
+        } else {
+            result = ledgerEntryRepository.findByWalletIdAndCurrencyOrderByIdDesc(walletId, currency, pageable);
+        }
+
+        return result.map(LedgerEntryItem::from);
+    }
+
+
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
@@ -2,11 +2,13 @@ package com.lemonpay.wallet.interfaces.api;
 
 import com.lemonpay.common.domain.Money;
 import com.lemonpay.wallet.application.ChargeResult;
+import com.lemonpay.wallet.application.LedgerEntryItem;
 import com.lemonpay.wallet.application.WalletQueryResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import org.springframework.data.domain.Page;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -106,7 +108,18 @@ public class WalletDto {
 
             @Schema(description = "전체 페이지 수", example = "5")
             int totalPages
-    ) { }
+    ) {
+        public static HistoryResponse from(UUID walletId, Page<LedgerEntryItem> page) {
+            return new HistoryResponse(
+                    walletId,
+                    page.getContent().stream().map(HistoryItem::from).toList(),
+                    page.getNumber(),
+                    page.getSize(),
+                    page.getTotalElements(),
+                    page.getTotalPages()
+            );
+        }
+    }
 
     @Schema(description = "거래 내역 단건")
     public record HistoryItem(
@@ -132,6 +145,18 @@ public class WalletDto {
 
             @Schema(description = "거래 일시", example = "2026-04-25T10:00:00")
             LocalDateTime createdAt
-    ) { }
+    ) {
+        public static HistoryItem from(LedgerEntryItem item) {
+            return new HistoryItem(
+                    item.id(),
+                    item.currency().toString(),
+                    item.amount(),
+                    item.direction().toString(),
+                    item.entryType().toString(),
+                    item.balanceAfter(),
+                    item.createdAt()
+            );
+        }
+    }
 
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletDto.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -85,5 +86,52 @@ public class WalletDto {
             );
         }
     }
+
+    @Schema(description = "거래 내역 조회 응답 DTO")
+    public record HistoryResponse(
+            @Schema(description = "지갑 ID")
+            UUID walletId,
+
+            @Schema(description = "거래 내역 목록")
+            List<HistoryItem> content,
+
+            @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+            int page,
+
+            @Schema(description = "페이지 크기", example = "10")
+            int size,
+
+            @Schema(description = "전체 요소 수", example = "42")
+            long totalElements,
+
+            @Schema(description = "전체 페이지 수", example = "5")
+            int totalPages
+    ) { }
+
+    @Schema(description = "거래 내역 단건")
+    public record HistoryItem(
+            @Schema(description = "원장 항목 ID", example = "1")
+            Long id,
+
+            @Schema(description = "통화", example = "KRW")
+            String currency,
+
+            @Schema(description = "거래 금액", example = "10000.0000")
+            BigDecimal amount,
+
+            @Schema(description = "입출금 방향", example = "CREDIT",
+                    allowableValues = {"CREDIT", "DEBIT"})
+            String direction,
+
+            @Schema(description = "거래 유형", example = "CHARGE",
+                    allowableValues = {"CHARGE", "PAYMENT", "EXCHANGE_IN", "EXCHANGE_OUT", "REFUND"})
+            String entryType,
+
+            @Schema(description = "거래 후 잔액", example = "50000.0000")
+            BigDecimal balanceAfter,
+
+            @Schema(description = "거래 일시", example = "2026-04-25T10:00:00")
+            LocalDateTime createdAt
+    ) { }
 
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -48,7 +49,8 @@ public interface WalletV1ApiSpec {
             @PathVariable("walletId") UUID walletId,
 
             @Parameter(description = "통화 필터 (선택)", example = "KRW")
-            @RequestParam(required = false) String currency,
+            @RequestParam(value = "currency", required = false) String currency,
 
+            @ParameterObject
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable);
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
@@ -4,11 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
@@ -33,4 +37,18 @@ public interface WalletV1ApiSpec {
     ResponseEntity<WalletDto.BalancesResponse> getBalances(
             @Parameter(description = "지갑 ID", required = true)
             @PathVariable("walletId") UUID walletId);
+
+    @GetMapping("/{walletId}/history")
+    @Operation(
+            summary = "거래 내역 조회",
+            description = "지갑의 거래 내역을 최신순으로 페이징 조회합니다. currency 파라미터가 없으면 전체 통화를 반환합니다."
+    )
+    ResponseEntity<WalletDto.HistoryResponse> getHistory(
+            @Parameter(description = "지갑 ID", required = true)
+            @PathVariable("walletId") UUID walletId,
+
+            @Parameter(description = "통화 필터 (선택)", example = "KRW")
+            @RequestParam(required = false) String currency,
+
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable);
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -5,6 +5,7 @@ import com.lemonpay.common.domain.Money;
 import com.lemonpay.wallet.application.ChargeUseCase;
 import com.lemonpay.wallet.application.WalletQueryService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/wallets")
 @RequiredArgsConstructor
@@ -40,6 +42,14 @@ public class WalletV1Controller implements WalletV1ApiSpec {
 
     @Override
     public ResponseEntity<WalletDto.HistoryResponse> getHistory(UUID walletId, String currency, Pageable pageable) {
-        return null;
+        log.warn("getHistory - walletId: {}, currency: {}, pageable: {}", walletId, currency, pageable);       Currency currencyEnum = null;
+
+        if(currency != null && !currency.isBlank()) {
+            currencyEnum = Currency.valueOf(currency);
+        }
+        var resultPage = walletQueryService.queryLedgerEntries(walletId, currencyEnum, pageable);
+        return ResponseEntity.ok(
+                WalletDto.HistoryResponse.from(walletId, resultPage)
+        );
     }
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -5,6 +5,7 @@ import com.lemonpay.common.domain.Money;
 import com.lemonpay.wallet.application.ChargeUseCase;
 import com.lemonpay.wallet.application.WalletQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,4 +38,8 @@ public class WalletV1Controller implements WalletV1ApiSpec {
         );
     }
 
+    @Override
+    public ResponseEntity<WalletDto.HistoryResponse> getHistory(UUID walletId, String currency, Pageable pageable) {
+        return null;
+    }
 }


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
Wallet API 거래내역 조회 기능 추가하였습니다.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
- Wallet API 스펙 버전1에 - 거래내역 페이징 조회 API 를 추가하였습니다.

## 설계 결정
- currency 파라미터로 통화 필터링, 없으면 전체 반환
- 최신순(createdAt DESC) 페이징 조회
- LedgerEntryItem VO 로 도메인 엔티티 경계 보호
- PropertyReferenceException 400 처리 추가
  (GlobalExceptionHandler)

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- 없음

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- [x] 신규 엔드포인트: 
- GET /api/v1/wallets/{walletId}/history 엔드포인트 추가

## 테스트

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과

## 관련 이슈
<!-- Closes #이슈번호 -->
- [x] #18 
- [x] #50
