### PR TITLE
[Infra] dev 브랜치 Docker 기반 인프라 구성  

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.gradle
+build
+out
+.idea
+*.iml
+.DS_Store
+.env*
+docker
+docs
+README.md

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,16 @@
+# Dev 환경 환경변수 템플릿
+# 이 파일은 Git에 커밋됩니다 (실제 값 없음)
+# 실제 사용 시 .env.dev 로 복사하고 값을 채워주세요
+# cp .env.dev.example .env.dev
+
+# MySQL 컨테이너 설정 (docker-compose.dev.yml 에서 사용)
+MYSQL_ROOT_PASSWORD=changeme
+MYSQL_DATABASE=lemonpay_dev
+MYSQL_USER=lemonpay
+MYSQL_PASSWORD=changeme
+
+# Spring Boot 앱 설정 (bootRun 시 주입)
+DB_URL="jdbc:mysql://localhost:3306/lemonpay_dev?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true"
+DB_DRIVER=com.mysql.cj.jdbc.Driver
+DB_USERNAME=lemonpay
+DB_PASSWORD=changeme

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -11,6 +11,7 @@ MYSQL_PASSWORD=changeme
 
 # Spring Boot 앱 설정 (bootRun 시 주입)
 DB_URL="jdbc:mysql://localhost:3306/lemonpay_dev?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true"
+DB_URL_DOCKER="jdbc:mysql://mysql:3306/lemonpay_dev?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true"
 DB_DRIVER=com.mysql.cj.jdbc.Driver
 DB_USERNAME=lemonpay
 DB_PASSWORD=changeme

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+      branches: [dev, main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      # Gradle 공식 액션 - 빌드 캐시 + 의존성 캐시 자동 처리
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      # 현재는 단일 모듈 이므로 --continue 는 제외함
+      - name: Build
+        run: ./gradlew build
+
+      # 테스트 실패해도 리포트 수집은 항상 실행
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: "**/build/test-results/test/TEST-*.xml"
+          detailed_summary: true
+
+      - name: Docker build (main PR only)
+        if: github.base_ref == 'main'
+        run: docker build -t lemonpay-backend .

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ out/
 
 ### MacOS ###
 .DS_Store
+
+### Env ###
+.env.dev
+.env.prod
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# ---- Stage 1: Build ----
+FROM eclipse-temurin:21-jdk-jammy AS builder
+
+WORKDIR /app
+
+# 의존성 캐시 최적화: gradle 설정만 먼저 복사
+# 소스가 바뀌어도 이 레이어는 캐시 재사용
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+COPY gradle.properties .
+
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon
+
+# 소스 복사 후 빌드 (테스트 제외)
+COPY src src
+RUN ./gradlew bootJar --no-daemon -x test
+
+# ---- Stage 2: Run ----
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+# 보안: root 대신 전용 유저로 실행
+RUN addgroup --system lemonpay && adduser --system --ingroup lemonpay lemonpay
+USER lemonpay
+
+# builder에서 JAR만 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,8 @@ build:
 run:
 	set -a && source .env.dev && set +a && SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
 
-.PHONY: up up-db down ps logs logs-app logs-db build run
+# 테스트 실행
+test:
+	./gradlew test
+
+.PHONY: up up-db down ps logs logs-app logs-db build run test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+COMPOSE = docker compose -f docker/docker-compose.dev.yml --env-file .env.dev
+
+# MySQL + 앱 전체 실행
+up:
+	$(COMPOSE) up -d
+
+# MySQL만 실행 (로컬 bootRun 개발 시)
+up-db:
+	$(COMPOSE) up -d mysql
+
+# 중지 및 컨테이너 제거
+down:
+	$(COMPOSE) down
+
+# 컨테이너 상태 확인
+ps:
+	$(COMPOSE) ps
+
+# 로그 확인 (전체)
+logs:
+	$(COMPOSE) logs -f
+
+# 앱 로그만
+logs-app:
+	$(COMPOSE) logs -f app
+
+# MySQL 로그만
+logs-db:
+	$(COMPOSE) logs -f mysql
+
+# 도커 이미지 빌드
+build:
+	docker build -t lemonpay-backend:dev .
+
+# 로컬 bootRun (MySQL 컨테이너에 붙어서 실행)
+run:
+	set -a && source .env.dev && set +a && SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
+
+.PHONY: up up-db down ps logs logs-app logs-db build run

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,31 @@
+name: lemonpay-dev
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: lemonpay-mysql-dev
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - lemonpay-mysql-dev-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  lemonpay-mysql-dev-data:
+
+
+# bridge는 컨테이너들끼리 통신할 수 있는 가상 네트워크
+# 따로 명시하는 경우는 2가지
+# (1) 서비스가 여러 개로 늘어나는 상황에서 네트워크를 분리하고 싶을 때 (db-network, app-network 따로 두는 경우)
+# (2)  외부에서 이미 만들어둔 네트워크에 붙이고 싶을 때 (external: true)
+# network.default.driver:bridge

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -20,6 +20,24 @@ services:
       retries: 5
       start_period: 30s
 
+  app:
+    image: lemonpay-backend:dev
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    container_name: lemonpay-app-dev
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      DB_URL: ${DB_URL_DOCKER}
+      DB_DRIVER: ${DB_DRIVER}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+    depends_on:
+      mysql:
+        condition: service_healthy
+
 volumes:
   lemonpay-mysql-dev-data:
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,27 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    driver-class-name: ${DB_DRIVER}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+
+springdoc:
+  use-fqn: true
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
dev 브랜치 통합 환경 재현을 위한 Docker 기반 인프라 구성하였습니다.
- 구체적으로 MySQL 컨테이너화 및 Spring Boot 앱 이미지 빌드 환경을 구성하여 dev 환경의 재현성과 배포 기반을 마련하였습니다.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
 ### 추가된 파일                                                                                                                                                                                                                                                            
  - `Dockerfile` : Spring Boot 앱 이미지 빌드 정의                                                                                                      
  - `docker/docker-compose.dev.yml` : MySQL + 앱 컨테이너 구성      
  - `src/main/resources/application-dev.yml` : dev 프로파일 MySQL 접속 설정                                                                             
  - `.env.dev.example` — 환경변수 템플릿 (실제 값 없이 커밋)                                                                                          
  - `Makefile` — Docker 명령어 단축 정의                            
  - `.dockerignore` — 이미지 빌드 시 불필요한 파일 제외
 - `.github/workflows/ci.yml` : 구현 과제시 main, dev에 대상으로 기본적인 ci 검증 코드 작성
### 수정된 파일
  - `.gitignore` : .env.dev, .env.prod 등 시크릿 파일 추가
 
## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->
1. DB만 Docker, 앱은 로컬 실행 분리
- 매일 개발 시에는 make up-db로 MySQL만 컨테이너로 띄우고 앱은 make run(bootRun)으로 로컬 실행한다. 
- 코드 변경 시 이미지 재빌드 없이 즉시 반영되고 IDE 디버깅이 가능하다. 
- make up으로 앱까지 컨테이너화하는 방식은 dev 브랜치 통합 환경 재현 목적으로만 사용한다.

2. 환경변수 완전 분리
- DB 접속 정보, 비밀번호를 application-dev.yml에 하드코딩하지 않고 .env.dev에서 주입한다. 
- .env.dev는 .gitignore로 커밋에서 제외하고 .env.dev.example만 커밋하여 온보딩 가이드로 활용 가능함.

3. DB_URL을 실행 방식에 따라 분리
- 컨테이너 내부에서 localhost는 자기 자신을 가리키므로 MySQL 서비스에 접근할 수 없다. 
- 로컬 bootRun용(DB_URL, localhost:3306)과 컨테이너용(DB_URL_DOCKER, mysql:3306)을 별도로 정의한다.

4. Multi-stage Dockerfile
- Stage 1(JDK)에서 빌드 후 Stage 2(JRE)에 JAR만 복사한다. 
- 빌드 도구를 최종 이미지에서 제외하여 이미지 크기를 줄이고 보안 노출을 최소화한다. 
- Gradle 설정을 소스보다 먼저 COPY하여 소스 변경 시 의존성 레이어 캐시를 재사용한다.


## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- dev mysql 관련 도커 내부 호스트 mysql:3306 사용

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- 없음

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과


## 관련 이슈
<!-- Closes #이슈번호 -->

## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
