### PR TITLE
Feature/wallet 통합테스트 구현 및 동시성 테스트 작성

### DIFF
--- a/src/main/java/com/lemonpay/common/config/LocalDataInitializerConfig.java
+++ b/src/main/java/com/lemonpay/common/config/LocalDataInitializerConfig.java
@@ -9,6 +9,7 @@ import com.lemonpay.member.domain.Member;
 import com.lemonpay.member.domain.MemberRepository;
 import com.lemonpay.wallet.domain.Wallet;
 import com.lemonpay.wallet.domain.WalletBalance;
+import com.lemonpay.wallet.domain.WalletBalanceRepository;
 import com.lemonpay.wallet.domain.WalletRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ public class LocalDataInitializerConfig {
     private final MemberRepository memberRepository;
     private final WalletRepository walletRepository;
     private final LedgerEntryRepository ledgerEntryRepository;
+    private final WalletBalanceRepository walletBalanceRepository;
 
     @Bean
     public ApplicationRunner localDataInitializer() {
@@ -63,6 +65,7 @@ public class LocalDataInitializerConfig {
     private void charge(Wallet wallet, Money amount) {
         WalletBalance balance = wallet.getBalance(amount.currency());
         balance.increase(amount);
+        walletBalanceRepository.save(balance);
 
         LedgerEntry ledgerEntry = LedgerEntry.of(
                 wallet.getId(),

--- a/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseIntegrationTest.java
+++ b/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseIntegrationTest.java
@@ -1,0 +1,239 @@
+package com.lemonpay.wallet.application;
+
+import com.lemonpay.common.auth.UserContext;
+import com.lemonpay.common.auth.UserContextHolder;
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.ledger.domain.Direction;
+import com.lemonpay.ledger.domain.EntryType;
+import com.lemonpay.ledger.domain.LedgerEntry;
+import com.lemonpay.ledger.domain.LedgerEntryRepository;
+import com.lemonpay.member.domain.Member;
+import com.lemonpay.member.domain.MemberRepository;
+import com.lemonpay.wallet.domain.*;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+@SpringBootTest
+public class ChargeUseCaseIntegrationTest {
+
+    @Autowired private ChargeUseCase chargeUseCase;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private WalletBalanceService walletBalanceService;
+    @Autowired private WalletBalanceRepository walletBalanceRepository;
+    @Autowired private LedgerEntryRepository ledgerEntryRepository;
+
+    private Member savedMember;
+    private Wallet savedWallet;
+    private WalletBalance savedWalletBalance;
+
+    private static final BigDecimal MAX_KRW_CHARGE_AMOUNT = BigDecimal.valueOf(1_000_000);
+
+    @BeforeEach
+    public void init() {
+        savedMember = memberRepository.save(
+                Member.create("test@test.com", "test", "+821012341234"));
+        savedWallet = walletRepository.save(Wallet.create(savedMember, "testWallet", "VASC-V1"));
+        savedWalletBalance = walletBalanceRepository
+                .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)
+                .orElseThrow();
+    }
+
+    @AfterEach
+    public void clean() {
+        UserContextHolder.clear();
+    }
+
+
+    @Test
+    @DisplayName("KRW 가 정상적으로 충전되면 KRW 지갑 잔액이 충전 금액 만큼 증가하고 원장 기록도 생성된다.")
+    void chargeSuccess_thenBalanceUpdateAndLedgerEntryInsertCorrectly() {
+        // given
+        UserContextHolder.set(new UserContext(savedMember.getId()));
+        Money chargeAmount = Money.won(1_000_000);
+        Money beforeChargeAmount = savedWalletBalance.toMoney();
+
+        // when
+        ChargeResult chargeResult = chargeUseCase.charge(savedWallet.getId(), chargeAmount);
+
+        // then 1 - 반환값 검증
+        assertThat(chargeResult).isNotNull();
+        assertThat(chargeResult.walletId()).isEqualTo(savedWallet.getId());
+        assertThat(chargeResult.chargeMoney()).isEqualTo(chargeAmount);
+
+        // then 2 - 잔액 검증
+        WalletBalance afterBalance = walletBalanceService.getWalletBalance(savedWallet.getId(), Currency.KRW);
+        assertThat(afterBalance.getBalance()).isEqualByComparingTo(beforeChargeAmount.amount().add(chargeAmount.amount()));
+
+        // then 3 - 원장 검증
+        Page<LedgerEntry> ledgerPage =
+                ledgerEntryRepository.findByWalletIdOrderByIdDesc(savedWallet.getId(), PageRequest.of(0, 10));
+
+        assertThat(ledgerPage.getContent()).hasSize(1);
+
+        LedgerEntry ledgerEntry = ledgerPage.getContent().get(0);
+        assertThat(ledgerEntry.getWalletId()).isEqualTo(savedWallet.getId());
+        assertThat(ledgerEntry.getCurrency()).isEqualTo(Currency.KRW);
+        assertThat(ledgerEntry.getAmount()).isEqualByComparingTo(chargeAmount.amount());
+        assertThat(ledgerEntry.getBalanceAfter()).isEqualByComparingTo(chargeAmount.amount());
+        assertThat(ledgerEntry.getEntryType()).isEqualTo(EntryType.CHARGE);
+        assertThat(ledgerEntry.getDirection()).isEqualTo(Direction.CREDIT);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 지갑을 충전하려고 하면 접근 거부 예외가 발생하며 DB 반영은 없다.")
+    void chargeThrowsException_whenTryingToChargeOthers() {
+        // given
+        UserContextHolder.set(new UserContext(UUID.randomUUID()));
+        Money chargeAmount = Money.won(1_000_000);
+        BigDecimal beforeChargeAmount = savedWalletBalance.getBalance();
+        int beforeLedgerSize = ledgerEntryRepository
+                .findByWalletIdOrderByIdDesc(savedWallet.getId(), PageRequest.of(0, 10))
+                .getContent()
+                .size();
+
+        // when & then
+        assertThatThrownBy(() -> chargeUseCase.charge(savedWallet.getId(), chargeAmount))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.FORBIDDEN);
+
+        WalletBalance afterBalance = walletBalanceRepository
+                .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)
+                .orElseThrow();
+
+        int afterLedgerSize = ledgerEntryRepository
+                .findByWalletIdOrderByIdDesc(savedWallet.getId(), PageRequest.of(0, 10))
+                .getContent()
+                .size();
+
+        assertThat(afterBalance.getBalance()).isEqualByComparingTo(beforeChargeAmount);
+        assertThat(afterLedgerSize).isEqualTo(beforeLedgerSize);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 충전 정책으로 충전하려고 할 때, 예외가 발생하고 DB 반영은 없다.")
+    void chargeThrowsException_whenTryingWithInvalidPolicy() {
+        // given
+        UserContextHolder.set(new UserContext(savedMember.getId()));
+        Money chargeAmount = Money.of(MAX_KRW_CHARGE_AMOUNT.add(BigDecimal.valueOf(1000)), Currency.KRW);
+
+        BigDecimal beforeChargeAmount = savedWalletBalance.getBalance();
+        int beforeLedgerSize = ledgerEntryRepository
+                .findByWalletIdOrderByIdDesc(savedWallet.getId(), PageRequest.of(0, 10))
+                .getContent()
+                .size();
+
+        // when & then
+        assertThatThrownBy(() -> chargeUseCase.charge(savedWallet.getId(), chargeAmount))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.INVALID_CHARGE_AMOUNT);
+
+        WalletBalance afterBalance = walletBalanceRepository
+                .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)
+                .orElseThrow();
+
+        int afterLedgerSize = ledgerEntryRepository
+                .findByWalletIdOrderByIdDesc(savedWallet.getId(), PageRequest.of(0, 10))
+                .getContent()
+                .size();
+
+        assertThat(afterBalance.getBalance()).isEqualByComparingTo(beforeChargeAmount);
+        assertThat(afterLedgerSize).isEqualTo(beforeLedgerSize);
+
+    }
+
+
+    @Test
+    @DisplayName("동시 충전 요청 시 낙관적 락 충돌이 발생하면 성공 건만 잔액과 원장에 반영된다. (retry 로직 없음)")
+    void chargeConcurrencyTest() throws InterruptedException {
+        // given
+        int tryCount = 2;
+        Money chargeAmount = Money.won(10_000);
+        BigDecimal beforeAmount = savedWalletBalance.getBalance();
+
+        ExecutorService executor = Executors.newFixedThreadPool(tryCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(tryCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < tryCount; i++) {
+            executor.submit(() -> {
+                try {
+                    UserContextHolder.set(new UserContext(savedMember.getId()));
+                    startLatch.await();
+
+                    chargeUseCase.charge(savedWallet.getId(), chargeAmount);
+                    successCount.incrementAndGet();
+                } catch (ObjectOptimisticLockingFailureException e) {
+                    failCount.incrementAndGet();
+                    log.warn("낙관적 락 충돌 - 동시성 제어 정상 작동함");
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    UserContextHolder.clear();
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // when
+        startLatch.countDown();
+        boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
+        try {
+            assertThat(completed).isTrue(); // 타임아웃 자체도 실패 처리
+        } finally {
+            // assertion 실패에 따른 쓰레드 미반환 대응
+            executor.shutdown();
+        }
+
+        // then 1 - 성공/실패 건수
+        assertThat(successCount.get() + failCount.get()).isEqualTo(tryCount);
+        assertThat(successCount.get()).isBetween(1, tryCount);
+
+        // then 2 - 최종 잔액 검증
+        WalletBalance afterBalance = walletBalanceRepository
+                .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)
+                .orElseThrow();
+        assertThat(afterBalance.getBalance())
+                .isEqualByComparingTo(
+                        beforeAmount.add(chargeAmount.amount().multiply(BigDecimal.valueOf(successCount.get())))
+                );
+
+        // then 3 - 원장 건수 검증
+        Page<LedgerEntry> ledgerPage =
+                ledgerEntryRepository.findByWalletIdOrderByIdDesc(savedWallet.getId(), PageRequest.of(0, 10));
+        assertThat(ledgerPage.getContent()).hasSize(successCount.get());
+
+    }
+
+    // TODO(idempotency): 동일 거래 중복 요청 시 멱등성 보장 테스트 추가
+    // TODO(retry): 네트워크 지연/타임아웃으로 인한 재시도 시 잔액 중복 증가 방지 테스트 추가
+
+}

--- a/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseIntegrationTest.java
+++ b/src/test/java/com/lemonpay/wallet/application/ChargeUseCaseIntegrationTest.java
@@ -26,10 +26,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import java.math.BigDecimal;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,8 +51,16 @@ public class ChargeUseCaseIntegrationTest {
 
     @BeforeEach
     public void init() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        int randomNumber = ThreadLocalRandom.current().nextInt(10_000_000, 100_000_000);
         savedMember = memberRepository.save(
-                Member.create("test@test.com", "test", "+821012341234"));
+                Member.create(
+                        "test-" + suffix + "@test.com",
+                        "test-" + suffix,
+                        "+8210" + randomNumber
+                )
+        );
+
         savedWallet = walletRepository.save(Wallet.create(savedMember, "testWallet", "VASC-V1"));
         savedWalletBalance = walletBalanceRepository
                 .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->

지갑 충전 유즈케이스에 대한 실제 DB 기반 통합테스트와 
낙관적 락 기반 동시성 테스트를 추가하였습니다.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
  - `ChargeUseCaseIntegrationTest` 추가
  - 정상 KRW 충전 시 잔액 증가 및 원장 기록 검증 테스트 추가
  - 인가 실패 시 잔액/원장 불변 검증 테스트 추가
  - 충전 정책 위반 시 잔액/원장 불변 검증 테스트 추가
  - 동시 충전 요청 시 낙관적 락 충돌이 발생하면 성공 건만 반영되는 동시성 테스트 추가

## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->
- 단위테스트에서 이미 경계값과 정책 검증을 수행하고 있으므로, 통합테스트는 실제 DB 반영 및 트랜잭션 흐름 검증에 집중하였습니다.
  - 동시성 테스트는 `@Version` 기반 낙관적 락이 적용된 현재 구조를 기준으로 작성하였으며, retry 로직이 없으므로 충돌 시 일부 요청 실패를 허용하는 방향으로 검증하였습니다.
  - 동일 거래의 중복 재전송(Idempotency)은 아직 도입하지 않았으며, 후속 설계 대상으로 분리하였습니다.

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- 없음


## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- 없음

## 테스트
  - [x] `ChargeUseCaseIntegrationTest` 추가
  - [x] 정상 충전 통합테스트
  - [x] 인가 실패 통합테스트
  - [x] 충전 정책 실패 통합테스트
  - [x] 낙관적 락 동시성 테스트

## 체크리스트
  - [x] 관련 테스트 작성
  - [x] 로컬 테스트 실행 및 확인
  - [x] 전체 빌드 확인

## 관련 이슈
<!-- Closes #이슈번호 -->
Closes: #21 , #27
## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
