### PR TITLE
feat(merchant): 가맹점 도메인 추가 및 MVP 문서 동기화

### DIFF
--- a/docs/01-requirements.md
+++ b/docs/01-requirements.md
@@ -41,6 +41,12 @@
 | US-M01 | **신규 사용자**로서, **회원가입 시 지갑이 자동으로 생성**되기를 원한다. **바로 서비스를 이용하기 위해서**이다. | Must |
 | US-M02 | **회원**으로서, **로그인하여 지갑과 거래 내역에 접근**하고 싶다. **금융 데이터를 안전하게 보호하기 위해서**이다. | Must |
 
+### 1.5 가맹점 (Merchant)
+| ID      | 유저 스토리 | 우선순위 |
+|---------|-----------|---------|
+| US-MC01 | **가맹점**으로서, **레몬페이에 결제 요청을 보내고 결제 결과를 callback으로 받고** 싶다. **결제 처리를 자동화하기 위해서**이다. | Must |
+| US-MC02 | **가맹점**으로서, **내 가맹점으로 발생한 결제를 정산 대상으로 식별**하고 싶다. **실제 수취 금액을 관리하기 위해서**이다. | Must |
+
 ---
 
 ## 2. 기능적 요구사항 (Functional Requirements)
@@ -88,6 +94,16 @@
 |----|---------|-------------------------------|
 | FR-401 | 시스템은 이메일 기반 회원 가입을 지원해야 한다. | - 이메일 유니크 제약 조건 <br> - 회원 상태: ACTIVE, SUSPENDED, CLOSED <br> - 가입 시 지갑 자동 생성 (FR-001) |
 | FR-402 | 시스템은 기본 인증(authentication)을 지원해야 한다. | - 세션 기반 또는 토큰 기반 인증 (포트폴리오 범위) <br> - 보호된 엔드포인트는 유효한 인증 필요 |
+
+
+### 2.6 가맹점 도메인 (Merchant Domain)
+
+| ID     | 요구사항 | 수용 기준 (Acceptance Criteria) |
+|--------|------|-----------------------------|
+| FR-501 | 시스템은 결제 요청의 수취 주체가 되는 가맹점 정보를 관리해야 한다. | - Merchant는 고유 ID, name, callbackUrl, status를 가진다 <br> - 상태: ACTIVE, SUSPENDED, CLOSED <br> - callbackUrl은 결제 결과를 가맹점 서버로 통지하는 용도로 사용된다 |
+| FR-502 | 시스템은 결제 요청 전에 가맹점의 결제 가능 상태를 검증해야 한다. | - ACTIVE 상태의 가맹점만 결제 요청 가능 <br> - SUSPENDED, CLOSED 상태의 가맹점은 결제 요청 불가 <br> - 결제 불가 상태에서는 명확한 오류를 반환한다 |
+
+
 
 ---
 
@@ -169,17 +185,19 @@
            |  - direction    |       |  - exchangeRate   |
            |  - balanceAfter |       |  - status (FSM)   |
            |  - transactionId|       |  - merchantId     |
-           +-----------------+       +-------------------+
+           +-----------------+       +---------+---------+
                                               |
-                                    +---------+---------+
-                                    |ExchangeTransaction|
-                                    |  (Aggregate Root) |
-                                    |                   |
-                                    |  - sourceCurrency |
-                                    |  - targetCurrency |
-                                    |  - exchangeRate   |
-                                    |  - rateSource     |
-                                    +-------------------+
+                        +---------------------+---------------------+
+                        |                                           |
+              +---------+---------+                       +---------+---------+
+              |      Merchant     |                       |ExchangeTransaction|
+              |  (Aggregate Root) |                       |  (Aggregate Root) |
+              |                   |                       |                   |
+              |  - name           |                       |  - sourceCurrency |
+              |  - callbackUrl    |                       |  - targetCurrency |
+              |  - status         |                       |  - exchangeRate   |
+              +-------------------+                       |  - rateSource     |
+                                                          +-------------------+
 ```
 
 ### 4.2 Aggregate 경계
@@ -237,6 +255,60 @@
 | US-E03 | FR-203 | NFR-301 | Sprint 3 |
 | US-M01 | FR-001, FR-401 | - | Sprint 1 |
 | US-M02 | FR-402 | NFR-202, NFR-204 | Sprint 1 |
+
+---
+
+## 6. MVP 확정 요건 (2026-04-25 추가)
+
+> 이 섹션은 MVP 개념 확정에 따라 추가된 요건이다.
+> 현재 구현 우선순위는 `Merchant`, `PaymentTransaction`, 페이머니 결제 흐름, 정산 개요까지로 한정한다.
+> 상세 설계는 `docs/07-payment-flow.md`, `docs/08-merchant-settlement.md`, `docs/extension/` 하위 문서를 참조한다.
+
+### 6.1 현재 MVP 본 요구사항
+
+| ID | 요구사항 | 수용 기준 (Acceptance Criteria) |
+|----|---------|-------------------------------|
+| FR-M01 | 시스템은 가맹점 정보를 등록하고 상태를 관리할 수 있어야 한다. | - Merchant 상태: ACTIVE / SUSPENDED / CLOSED <br> - ACTIVE 가맹점만 결제 요청 가능 <br> - API Key 발급 및 인증은 향후 확장 범위 |
+| FR-M02 | 시스템은 가맹점의 결제 요청을 수신하고 결제 세션을 생성해야 한다. | - `POST /api/v1/payments` 로 결제 요청 수신 <br> - 요청 항목: merchantId, amount, currency, orderId, callbackUrl <br> - 응답: paymentSessionId, redirectUrl (레몬페이 결제창 URL) |
+| FR-M03 | 시스템은 결제 완료 후 가맹점 callbackUrl로 결과를 전송해야 한다. | - Callback 전송 항목: paymentId, status, amount, currency, txNo, orderId <br> - HTTP POST 방식으로 전송 <br> - callback 재시도 및 실패 이력 관리 기능은 향후 확장 범위 |
+| FR-M04 | 시스템은 가맹점의 결제/정산 조회 기능을 확장할 수 있어야 한다. | - 결제 이력 조회 API 및 정산 이력 조회 API는 향후 확장 범위 |
+
+**신규 유저 스토리**:
+
+| ID | 유저 스토리 | 우선순위 |
+|----|-----------|---------|
+| US-MC01 | **가맹점**으로서, **레몬페이에 결제 요청을 보내고 결과를 webhook으로 받고** 싶다. **결제 처리를 자동화하기 위해서**이다. | Must |
+| US-CH01 | **회원**으로서, **레몬페이 페이머니를 충전**하고 싶다. **레몬페이로 결제하기 위해 잔액을 미리 채워두기 위해서**이다. | Must |
+| US-CH02 | **회원**으로서, **충전 후 즉시 변경된 잔액을 확인**하고 싶다. **충전이 정상적으로 처리되었는지 확인하기 위해서**이다. | Must |
+
+**추가 요구사항**:
+
+| ID | 요구사항 | 수용 기준 (Acceptance Criteria) |
+|----|---------|-------------------------------|
+| FR-CH01 | 시스템은 외부 결제 결과를 기반으로 페이머니를 충전해야 한다. | - 외부 결제 성공 시에만 페이머니 잔액 증가 <br> - 외부 결제 실패 시 페이머니 잔액 변동 없음 (원자성 보장) <br> - 기존 FR-004 충전 한도 동일 적용 (최소 1,000 KRW, 최대 10,000,000 KRW) |
+| FR-CH02 | 시스템은 충전 처리 시 외부 결제 참조 정보를 기록할 수 있어야 한다. | - 외부 결제 참조 ID 기록은 향후 확장 범위 <br> - 현재 MVP에서는 충전 원장 기록과 잔액 반영에 집중 |
+| FR-CH03 | 시스템은 페이머니 충전 완료 후 즉시 잔액에 반영되어야 한다. | - 충전 완료 응답에 `balanceAfter` (충전 후 잔액) 포함 <br> - 스냅샷 잔액(WalletBalance.balance)과 원장 항목 원자적으로 갱신 (기존 FR-003 동일) |
+
+| FR-ST01 | 시스템은 결제 완료 건을 가맹점 정산 대상으로 식별할 수 있어야 한다. | - `PaymentTransaction.status = COMPLETED` 인 결제 건만 정산 대상 <br> - 정산은 월말 배치 기준으로 집계 <br> - Settlement 상세 엔티티와 정산 조회 API는 향후 확장 범위 |
+
+---
+
+### 6.2 향후 확장 범위
+
+> 아래 항목은 `07-payment-flow.md` 기준 현재 MVP 본 구현 범위에서 제외한다.
+
+- 결제수단 관리 (`PaymentMethod`) 및 토큰화 API
+- 결제수단 등록/조회/삭제 요구사항 (`FR-P01~P03`, `US-PM01~03`)
+- 가맹점 API Key 발급 및 인증
+- 가맹점 결제/정산 이력 조회 API
+- 결제수단 토큰 기반 충전
+- 정산 상세 엔티티 및 정산 조회 API
+
+상세 초안은 아래 문서에서 관리한다.
+
+- `docs/extension/01-payment-method-design.md`
+- `docs/extension/02-merchant-api-design.md`
+- `docs/extension/03-payment-method-based-charge.md`
 
 ---
 

--- a/docs/02-erd.md
+++ b/docs/02-erd.md
@@ -57,6 +57,10 @@
 - `rate_source` — REALTIME / CACHED / FALLBACK. 사후 정산 및 감사 추적용
 - `source_amount`, `target_amount` — 각각 DECIMAL(18,4). 환전 전/후 금액
 
+### Merchant (가맹점)
+- PK: UUID (`BINARY(16)`) — 외부 노출 ID. 순서/수량 추론 방지
+- 논리 삭제: `status = CLOSED` (물리 삭제 없음)
+- `callbackUrl`  - 레몬페이 결제 결과를 전송할 가맹점 별 callbackUrl
 ---
 
 ## ERD
@@ -121,7 +125,7 @@ erDiagram
         decimal(18_8)  exchange_rate          "적용 환율"
         varchar(20)    status                 "PENDING | APPROVED | COMPLETED | FAILED | CANCELLED"
         varchar(64)    idempotency_key    UK  "중복 결제 방지"
-        varchar(64)    merchant_id            "가맹점 ID"
+        binary(16)     merchant_id            "Merchant.id 참조. 가맹점 ID"
         timestamp      created_at
         timestamp      updated_at
         timestamp      completed_at           "결제 완료 시각, nullable"
@@ -141,6 +145,15 @@ erDiagram
         timestamp      created_at
         timestamp      updated_at
     }
+    
+    Merchant {  
+        binary(16)    id           PK  "UUID, 외부 노출용"
+        varchar(100)  name             "가맹점 논리명"
+        varchar(5000) callbackUrl       "레몬페이 결제 결과를 전송할 가맹점 별 callbackUrl" 
+        varchar(20)   status            "ACTIVE|SUSPENDED|CLOSED"
+        timestamp      created_at
+        timestamp      updated_at
+    }
 
     %% Relationships
     Member          ||--o{ Wallet              : "has"
@@ -148,6 +161,7 @@ erDiagram
     Wallet          ||--o{ LedgerEntry         : "records"
     Wallet          ||--o{ PaymentTransaction  : "pays"
     Wallet          ||--o{ ExchangeTransaction : "exchanges"
+    Merchant        ||--o{ PaymentTransaction  : "receives"
 ```
 
 ---

--- a/src/main/java/com/lemonpay/common/exception/ErrorType.java
+++ b/src/main/java/com/lemonpay/common/exception/ErrorType.java
@@ -13,12 +13,13 @@ public enum ErrorType {
     INVALID_CURRENCY(HttpStatus.BAD_REQUEST, "지원하지 않는 통화입니다."),
     INVALID_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, "충전 금액이 정책 범위를 벗어났습니다."),
     WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "지갑을 찾을 수 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "허용되지 않은 접근입니다."),
 
     // 422
     WALLET_NOT_CHARGEABLE(HttpStatus.UNPROCESSABLE_ENTITY, "충전이 불가능한 지갑 상태입니다."),
-    INVALID_WALLET_STATE_TRANSITION(HttpStatus.UNPROCESSABLE_ENTITY, "허용되지 않는 상태 전이입니다."),
+    INVALID_STATE_TRANSITION(HttpStatus.UNPROCESSABLE_ENTITY, "허용되지 않는 상태 전이입니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/lemonpay/merchant/domain/Merchant.java
+++ b/src/main/java/com/lemonpay/merchant/domain/Merchant.java
@@ -1,0 +1,66 @@
+package com.lemonpay.merchant.domain;
+
+import com.lemonpay.common.domain.BaseEntity;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "merchants")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Merchant extends BaseEntity {
+
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Column(columnDefinition = "BINARY(16)", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MerchantStatus status;
+
+    @Column(nullable = false, length = 5000)
+    private String callbackUrl;
+
+    private Merchant(String name, MerchantStatus status, String callbackUrl) {
+        this.name = name;
+        this.status = status;
+        this.callbackUrl = callbackUrl;
+    }
+
+    public static Merchant create(String name, String callbackUrl) {
+        return new Merchant(name, MerchantStatus.ACTIVE , callbackUrl);
+    }
+
+    public void suspend() {
+        this.status.validateTransition(MerchantStatus.SUSPENDED);
+        this.status = MerchantStatus.SUSPENDED;
+    }
+
+    public void close() {
+        this.status.validateTransition(MerchantStatus.CLOSED);
+        this.status = MerchantStatus.CLOSED;
+    }
+
+    public void activate() {
+        this.status.validateTransition(MerchantStatus.ACTIVE);
+        this.status = MerchantStatus.ACTIVE;
+    }
+
+    public void validatePayable() {
+        if(status != MerchantStatus.ACTIVE) {
+            throw new CoreException(ErrorType.INVALID_REQUEST, "가맹점이 결제 요청 보낼 수 없는 상태입니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/lemonpay/merchant/domain/MerchantRepository.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantRepository.java
@@ -1,0 +1,10 @@
+package com.lemonpay.merchant.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MerchantRepository {
+    Merchant save(Merchant merchant);
+    Optional<Merchant> findById(UUID id);
+    boolean existsById(UUID id);
+}

--- a/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
@@ -1,0 +1,46 @@
+package com.lemonpay.merchant.domain;
+
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class MerchantService {
+
+    private final MerchantRepository merchantRepository;
+
+    @Transactional(readOnly = true)
+    public Merchant getMerchantById(UUID id) {
+        return merchantRepository.findById(id)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public void validateMerchantPayable(UUID id) {
+        Merchant found = getMerchantById(id);
+        found.validatePayable();
+    }
+
+    @Transactional
+    public Merchant register(Merchant merchant) {
+        if(merchantRepository.existsById(merchant.getId())) {
+            throw new CoreException(ErrorType.INVALID_REQUEST, "이미 등록된 가맹점입니다.");
+        }
+        return merchantRepository.save(merchant);
+    }
+
+    @Transactional
+    public Merchant update(Merchant merchant) {
+        if(!merchantRepository.existsById(merchant.getId())) {
+            throw new CoreException(ErrorType.NOT_FOUND);
+        }
+
+        return merchantRepository.save(merchant);
+    }
+
+}

--- a/src/main/java/com/lemonpay/merchant/domain/MerchantStatus.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantStatus.java
@@ -1,0 +1,42 @@
+package com.lemonpay.merchant.domain;
+
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+
+public enum MerchantStatus {
+    ACTIVE {
+        @Override
+        public Set<MerchantStatus> allowedTransitions() {
+            return EnumSet.of(MerchantStatus.SUSPENDED, MerchantStatus.CLOSED);
+        }
+    },
+    SUSPENDED {
+        @Override
+        public Set<MerchantStatus> allowedTransitions() {
+            return EnumSet.of(MerchantStatus.ACTIVE, MerchantStatus.CLOSED);
+        }
+    },
+    CLOSED {
+        /**
+         * 가맹점 해지했다가 재가입하는 경우를 고려하여 CLOSED -> ACTIVE 상태 전이 허용함
+         * @return
+         */
+        @Override
+        public Set<MerchantStatus> allowedTransitions() {
+            return EnumSet.of(MerchantStatus.ACTIVE);
+        }
+    };
+
+    public abstract Set<MerchantStatus> allowedTransitions();
+    public boolean canTransitionTo(MerchantStatus next) { return allowedTransitions().contains(next); }
+    public void validateTransition(MerchantStatus next) {
+        if(!canTransitionTo(next)) {
+            throw new CoreException(ErrorType.INVALID_STATE_TRANSITION,
+                    "가맹점 상태 전이 불가: %s -> %s".formatted(this.name(), next.name()));
+        }
+    }
+}

--- a/src/main/java/com/lemonpay/merchant/infrastructure/MerchantJpaRepository.java
+++ b/src/main/java/com/lemonpay/merchant/infrastructure/MerchantJpaRepository.java
@@ -1,0 +1,10 @@
+package com.lemonpay.merchant.infrastructure;
+
+import com.lemonpay.merchant.domain.Merchant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MerchantJpaRepository extends JpaRepository<Merchant, UUID> {
+
+}

--- a/src/main/java/com/lemonpay/merchant/infrastructure/MerchantRepositoryImpl.java
+++ b/src/main/java/com/lemonpay/merchant/infrastructure/MerchantRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.lemonpay.merchant.infrastructure;
+
+import com.lemonpay.merchant.domain.Merchant;
+import com.lemonpay.merchant.domain.MerchantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class MerchantRepositoryImpl implements MerchantRepository {
+
+    private final MerchantJpaRepository jpaRepository;
+
+    @Override
+    public Merchant save(Merchant merchant) {
+        return jpaRepository.save(merchant);
+    }
+
+    @Override
+    public Optional<Merchant> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return jpaRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/domain/WalletStatus.java
+++ b/src/main/java/com/lemonpay/wallet/domain/WalletStatus.java
@@ -35,7 +35,7 @@ public enum WalletStatus {
     public void validateTransition(WalletStatus next) {
         if(!canTransitionTo(next)) {
             throw new CoreException(
-                    ErrorType.INVALID_WALLET_STATE_TRANSITION,
+                    ErrorType.INVALID_STATE_TRANSITION,
                     "지갑 상태 전이 불가: %s -> %s".formatted(this.name(), next.name()));
         }
     }

--- a/src/test/java/com/lemonpay/merchant/domain/MerchantTest.java
+++ b/src/test/java/com/lemonpay/merchant/domain/MerchantTest.java
@@ -1,0 +1,49 @@
+package com.lemonpay.merchant.domain;
+
+import com.lemonpay.common.exception.CoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MerchantTest {
+
+    @Nested
+    @DisplayName("가맹점 생성 테스트")
+    class Create {
+
+        @DisplayName("최초 가맹점 생성시, active 상태로 가맹점이 등록된다.")
+        void createMerchant_success() {
+            // given
+            String name = "Test Merchant";
+            String callbackUrl = "https://localhost:8080/testUrl";
+            // when
+            Merchant merchant = Merchant.create(name, callbackUrl);
+
+            // then
+            assertNotNull(merchant);
+            assertEquals(name, merchant.getName());
+            assertEquals(callbackUrl, merchant.getCallbackUrl());
+            assertEquals(MerchantStatus.ACTIVE, merchant.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("가맹점 상태 변경 테스트")
+    class Update {
+
+        @Test
+        @DisplayName("가맹점 상태가 supseneded 면 레몬페이 사용자는 가맹점으로 결제를 진행할 수 없다.")
+        void validatePayable_throwsException() {
+            // given
+            String name = "Test Merchant";
+            String callbackUrl = "https://localhost:8080/testUrl";
+            Merchant merchant = Merchant.create(name, callbackUrl);
+            merchant.suspend();
+
+            // when & then
+            assertThrows(CoreException.class, merchant::validatePayable);
+        }
+    }
+}


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
결제 요청의 수취 주체가 되는 Merchant 도메인의 최소 구조를 추가하고 관련 문서를 동기화함.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
1. 결제 요청의 수취 주체가 되는 Merchant 도메인의 최소 구조를 추가.
2. ACTIVE 상태의 가맹점만 결제 요청 가능하도록 도메인 규칙을 정의.
3. payment-flow, requirements, erd 문서를 현재 MVP 범위에 맞게 정리.
4. 결제수단, API Key, 결제수단 기반 충전 등 범위 외 항목은 extension 문서로 분리.

## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->
현재 MVP에서는 결제 처리 로직에 집중하기 위해 Merchant 도메인을 최소 범위로 설계.
> 정산, API Key, 결제수단 토큰화 등은 본 구현 범위에서 제외하고 후속 확장 항목으로 분리.

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- [x] 신규 테이블: merchants

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- 없음
- 
## 테스트
- [x] 단위 테스트 추가/수정 - 생성 테스트 1건 / 상태변경 예외 반환 테스트 1건

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과

## 관련 이슈
<!-- Closes #이슈번호 -->

## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
