### PR TITLE
[BE] PaymentTransaction API 스펙, 도메인 모델 및 상태머신, 유즈케이스 구현 및 통합테스트 개발 완료

### DIFF
--- a/docs/sequenceDiagrams/02-PaymentMvpUsecase.mermaid
+++ b/docs/sequenceDiagrams/02-PaymentMvpUsecase.mermaid
@@ -12,27 +12,33 @@ sequenceDiagram
 
     %% server to server
     Merchant ->>+ PaymentAPI: POST /api/v1/payments
+
+    PaymentAPI ->>+ Wallet: 지갑소유자 정보 확인
+    Wallet -->>- PaymentAPI: 지갑소유자 상이할 경우 예외발생
     PaymentAPI ->>+ MerchantDomain: merchantId 조회 및 ACTIVE 검증
     MerchantDomain -->>- PaymentAPI: Merchant 반환
 
     PaymentAPI ->>+ PaymentDomain: PENDING 결제 생성
     Note over PaymentDomain: status = PENDING
-    PaymentDomain -->>- PaymentAPI: paymentId 반환
+    PaymentDomain -->>- PaymentAPI: 결제 정보 반환 반환
 
-    PaymentAPI -->>- Merchant: paymentId, redirectUrl 반환
+    PaymentAPI -->>- Merchant: 결제 정보, redirectUrl 반환
 
     %% client's action
-    Member ->>+ PaymentAPI : POST /api/v1/payments/{paymentId}/approve
+    Member ->>+ PaymentAPI : POST /api/v1/payments/{txNo}/approve
 
     %% server
-    PaymentAPI ->>+ PaymentDomain: paymentId 조회
-    PaymentDomain -->>- PaymentAPI : payment 반환
+    PaymentAPI ->>+ Wallet: 지갑소유자 정보 확인
+    Wallet -->>- PaymentAPI: 지갑소유자 상이할 경우 예외발생
+    PaymentAPI ->>+ PaymentDomain: txNo로 거래정보 조회
+    PaymentDomain -->>- PaymentAPI : PaymentTransaction 반환
+
+    PaymentAPI ->>+ MerchantDomain: merchantId 조회 및 ACTIVE 검증
+    MerchantDomain -->>- PaymentAPI: Merchant 반환
 
     PaymentAPI ->>+ PaymentDomain: PENDING 상태 검증
     PaymentDomain -->>- PaymentAPI: 상태 검증 / 실패시 예외 throws
 
-    PaymentAPI ->>+ Wallet: Wallet 소유자 검증
-    Wallet -->>- PaymentAPI: 정상 응답 / 실패시 예외 throws
 
     PaymentAPI ->>+ Wallet: Wallet 잔액 재검증 및 차감
     Wallet -->>- PaymentAPI: 정상 응답 / 실패시 예외 throws
@@ -41,30 +47,35 @@ sequenceDiagram
     PaymentAPI ->>+ Ledger: PAYMENT / DEBIT 원장 생성
     Ledger -->>- PaymentAPI: 정상 응답 / 실패시 예외 throws
 
-    PaymentAPI ->>+ PaymentDomain : COMPLETED 상태 전이
+    PaymentAPI ->>+ PaymentDomain : 결제 상태 COMPLETED 상태 전이
     PaymentDomain -->>- PaymentAPI : 정상 응답 / 실패시 예외 throws
 
     PaymentAPI -->>- Member : 결제 승인 결과 반환
 
     %% client's action
-    Member ->>+ PaymentAPI: GET /api/v1/payments/{paymentId}
+    Member ->>+ PaymentAPI: GET /api/v1/payments/{txNo}
 
+    PaymentAPI ->>+ Wallet: 지갑소유자 정보 확인
+    Wallet -->>- PaymentAPI: 지갑소유자 상이할 경우 예외발생
     PaymentAPI ->>+ PaymentDomain : 결제 상세 조회
     PaymentDomain -->>- PaymentAPI : 결제 상세 결과 응답
 
-    PaymentAPI -->>- Member: 결제 상태/금액/가맹점/주문번호(DetailViewResponse DTO) 반환
+    PaymentAPI ->>+ MerchantDomain: merchant 도메인 조회
+    MerchantDomain -->>- PaymentAPI: Merchant 도메인 객체 반환
+
+    PaymentAPI -->>- Member: 결제 상태/금액/가맹점/주문번호(PaymentResult) 반환
 
     %% client's action
-    Member ->>+ PaymentAPI: POST /api/v1/payment/{paymentId}/cancel
+    Member ->>+ PaymentAPI: POST /api/v1/payment/{txNo}/cancel
 
     PaymentAPI ->>+ PaymentDomain : 결제 상세 조회
     PaymentDomain -->>- PaymentAPI : 결제 상세 결과 응답
-
-    PaymentAPI ->>+ PaymentDomain : 결제 취소 가능 검증 (status == PENDING)
-    PaymentDomain -->>- PaymentAPI : 결제 취소 가능 검증 응답 / 불가시 예외 throws
 
     PaymentAPI ->>+ PaymentDomain : cancel() 결제 취소 요청
     Note over PaymentDomain: PENDING -> CANCELLED
-    PaymentDomain -->>- PaymentAPI : 상태 변경 완료
+    PaymentDomain -->>- PaymentAPI : 상태 변경 완료 / 정의되지 않은 상태일 경우 예외
 
-    PaymentAPI -->>- Member: 결과 응답
+    PaymentAPI ->>+ MerchantDomain: merchant 도메인 조회
+    MerchantDomain -->>- PaymentAPI: Merchant 도메인 객체 반환
+
+    PaymentAPI -->>- Member: 결제 상태/금액/가맹점/주문번호(PaymentResult) 반환

--- a/docs/sequenceDiagrams/02-PaymentMvpUsecase.mermaid
+++ b/docs/sequenceDiagrams/02-PaymentMvpUsecase.mermaid
@@ -1,0 +1,70 @@
+sequenceDiagram
+    actor Merchant as 가맹점 서버
+    actor Member as 사용자
+    participant PaymentAPI as Payment API/UseCase
+    participant MerchantDomain as Merchant
+    participant PaymentDomain as PaymentTransaction
+    participant Wallet as Wallet/WalletBalance
+    participant Ledger as LedgerEntry
+
+    %% client's action
+    Member ->> Merchant: 사용자가 특정 가맹점에서 간편결제 중 레몬페이 결제를 선택한다
+
+    %% server to server
+    Merchant ->>+ PaymentAPI: POST /api/v1/payments
+    PaymentAPI ->>+ MerchantDomain: merchantId 조회 및 ACTIVE 검증
+    MerchantDomain -->>- PaymentAPI: Merchant 반환
+
+    PaymentAPI ->>+ PaymentDomain: PENDING 결제 생성
+    Note over PaymentDomain: status = PENDING
+    PaymentDomain -->>- PaymentAPI: paymentId 반환
+
+    PaymentAPI -->>- Merchant: paymentId, redirectUrl 반환
+
+    %% client's action
+    Member ->>+ PaymentAPI : POST /api/v1/payments/{paymentId}/approve
+
+    %% server
+    PaymentAPI ->>+ PaymentDomain: paymentId 조회
+    PaymentDomain -->>- PaymentAPI : payment 반환
+
+    PaymentAPI ->>+ PaymentDomain: PENDING 상태 검증
+    PaymentDomain -->>- PaymentAPI: 상태 검증 / 실패시 예외 throws
+
+    PaymentAPI ->>+ Wallet: Wallet 소유자 검증
+    Wallet -->>- PaymentAPI: 정상 응답 / 실패시 예외 throws
+
+    PaymentAPI ->>+ Wallet: Wallet 잔액 재검증 및 차감
+    Wallet -->>- PaymentAPI: 정상 응답 / 실패시 예외 throws
+
+
+    PaymentAPI ->>+ Ledger: PAYMENT / DEBIT 원장 생성
+    Ledger -->>- PaymentAPI: 정상 응답 / 실패시 예외 throws
+
+    PaymentAPI ->>+ PaymentDomain : COMPLETED 상태 전이
+    PaymentDomain -->>- PaymentAPI : 정상 응답 / 실패시 예외 throws
+
+    PaymentAPI -->>- Member : 결제 승인 결과 반환
+
+    %% client's action
+    Member ->>+ PaymentAPI: GET /api/v1/payments/{paymentId}
+
+    PaymentAPI ->>+ PaymentDomain : 결제 상세 조회
+    PaymentDomain -->>- PaymentAPI : 결제 상세 결과 응답
+
+    PaymentAPI -->>- Member: 결제 상태/금액/가맹점/주문번호(DetailViewResponse DTO) 반환
+
+    %% client's action
+    Member ->>+ PaymentAPI: POST /api/v1/payment/{paymentId}/cancel
+
+    PaymentAPI ->>+ PaymentDomain : 결제 상세 조회
+    PaymentDomain -->>- PaymentAPI : 결제 상세 결과 응답
+
+    PaymentAPI ->>+ PaymentDomain : 결제 취소 가능 검증 (status == PENDING)
+    PaymentDomain -->>- PaymentAPI : 결제 취소 가능 검증 응답 / 불가시 예외 throws
+
+    PaymentAPI ->>+ PaymentDomain : cancel() 결제 취소 요청
+    Note over PaymentDomain: PENDING -> CANCELLED
+    PaymentDomain -->>- PaymentAPI : 상태 변경 완료
+
+    PaymentAPI -->>- Member: 결과 응답

--- a/src/main/java/com/lemonpay/common/config/LocalDataInitializerConfig.java
+++ b/src/main/java/com/lemonpay/common/config/LocalDataInitializerConfig.java
@@ -1,12 +1,13 @@
 package com.lemonpay.common.config;
 
 import com.lemonpay.common.domain.Money;
-import com.lemonpay.ledger.domain.Direction;
 import com.lemonpay.ledger.domain.EntryType;
 import com.lemonpay.ledger.domain.LedgerEntry;
 import com.lemonpay.ledger.domain.LedgerEntryRepository;
 import com.lemonpay.member.domain.Member;
 import com.lemonpay.member.domain.MemberRepository;
+import com.lemonpay.merchant.domain.Merchant;
+import com.lemonpay.merchant.domain.MerchantRepository;
 import com.lemonpay.wallet.domain.Wallet;
 import com.lemonpay.wallet.domain.WalletBalance;
 import com.lemonpay.wallet.domain.WalletBalanceRepository;
@@ -27,6 +28,7 @@ public class LocalDataInitializerConfig {
 
     private final MemberRepository memberRepository;
     private final WalletRepository walletRepository;
+    private final MerchantRepository merchantRepository;
     private final LedgerEntryRepository ledgerEntryRepository;
     private final WalletBalanceRepository walletBalanceRepository;
 
@@ -49,6 +51,8 @@ public class LocalDataInitializerConfig {
             String email = "test" + suffix + "@lemonpay.com";
             String name = "test" + suffix;
             String phone = "+82101234" + suffix;
+            String merchantName = "store" + suffix;
+            String callbackUrl = String.format("https://www.%s.com/payments/%s", merchantName,suffix);
 
             Member member = Member.create(email, name,phone);
             memberRepository.save(member);
@@ -59,6 +63,9 @@ public class LocalDataInitializerConfig {
             charge(wallet, Money.won(50_000));
             charge(wallet, Money.usd("1000.00"));
             charge(wallet, Money.jpy(1_000));
+
+            Merchant merchant = Merchant.create(merchantName, callbackUrl);
+            merchantRepository.save(merchant);
         }
     }
 

--- a/src/main/java/com/lemonpay/config/OpenApiConfig.java
+++ b/src/main/java/com/lemonpay/config/OpenApiConfig.java
@@ -1,5 +1,6 @@
 package com.lemonpay.config;
 
+import com.lemonpay.payment.interfaces.api.PaymentV1Controller;
 import com.lemonpay.wallet.interfaces.api.WalletV1Controller;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -10,7 +11,6 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.HandlerMethod;
 
 @Configuration
@@ -55,6 +55,7 @@ public class OpenApiConfig {
      */
     private boolean requiresUserIdHeaderOnDocs(HandlerMethod handlerMethod) {
         Class<?> controllerType = handlerMethod.getBeanType();
-        return controllerType == WalletV1Controller.class;
+        return controllerType == WalletV1Controller.class
+                || controllerType == PaymentV1Controller.class;
     }
 }

--- a/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
@@ -43,4 +43,11 @@ public class MerchantService {
         return merchantRepository.save(merchant);
     }
 
+    @Transactional(readOnly = true)
+    public Merchant getPayableMerchant(UUID merchantId) {
+        Merchant merchant = getMerchantById(merchantId);
+        merchant.validatePayable();
+        return merchant;
+    }
+
 }

--- a/src/main/java/com/lemonpay/payment/application/PaymentCommand.java
+++ b/src/main/java/com/lemonpay/payment/application/PaymentCommand.java
@@ -1,0 +1,34 @@
+package com.lemonpay.payment.application;
+
+import com.lemonpay.common.domain.Currency;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public class PaymentCommand {
+
+    public record Create (
+            UUID walletId,
+            UUID merchantId,
+            Currency currency,
+            BigDecimal amount,
+            Currency settlementCurrency,
+            BigDecimal settlementAmount,
+            BigDecimal exchangeRate,
+            String orderId,
+            String idempotencyKey
+    ) { }
+
+    public record Approve (
+            String txNo
+    ) { }
+
+    public record Cancel (
+            String txNo
+
+    ) { }
+
+    public record Query (
+        String txNo
+    ) { }
+}

--- a/src/main/java/com/lemonpay/payment/application/PaymentResult.java
+++ b/src/main/java/com/lemonpay/payment/application/PaymentResult.java
@@ -1,0 +1,40 @@
+package com.lemonpay.payment.application;
+
+import com.lemonpay.payment.domain.PaymentTransaction;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PaymentResult(
+        String txNo,
+        String status,
+        UUID walletId,
+        UUID merchantId,
+        String merchantName,
+        BigDecimal amount,
+        String currency,
+        BigDecimal settlementAmount,
+        String settlementCurrency,
+        BigDecimal exchangeRate,
+        LocalDateTime createdAt,
+        LocalDateTime completedAt,
+        LocalDateTime cancelledAt
+) {
+    public static PaymentResult of(PaymentTransaction tx, String merchantName) {
+        return new PaymentResult(
+                tx.getTxNo(),
+                tx.getStatus().name(),
+                tx.getWalletId(),
+                tx.getMerchantId(),
+                merchantName,
+                tx.getAmount(),
+                tx.getCurrency().name(),
+                tx.getSettlementAmount(),
+                tx.getSettlementCurrency().name(),
+                tx.getExchangeRate(),
+                tx.getCreatedAt(),
+                tx.getCompletedAt(),
+                tx.getCancelledAt());
+    }
+}

--- a/src/main/java/com/lemonpay/payment/application/PaymentTxNoGenerator.java
+++ b/src/main/java/com/lemonpay/payment/application/PaymentTxNoGenerator.java
@@ -1,0 +1,31 @@
+package com.lemonpay.payment.application;
+
+import com.lemonpay.payment.domain.PaymentTxNoSequence;
+import com.lemonpay.payment.infrastructure.PaymentTxNoSequenceJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentTxNoGenerator {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
+
+    private final PaymentTxNoSequenceJpaRepository repository;
+
+    @Transactional
+    public String generate() {
+        String sequenceDate = LocalDate.now().format(DATE_FORMATTER);
+
+        PaymentTxNoSequence sequence = repository.findBySequenceDateForUpdate(sequenceDate)
+                .orElseGet(() -> repository.save(PaymentTxNoSequence.create(sequenceDate)));
+
+        Long sequenceValue = sequence.issue();
+
+        return "%s%010d".formatted(sequenceDate, sequenceValue);
+    }
+}

--- a/src/main/java/com/lemonpay/payment/application/PaymentUseCase.java
+++ b/src/main/java/com/lemonpay/payment/application/PaymentUseCase.java
@@ -86,4 +86,15 @@ public class PaymentUseCase {
 
         return PaymentResult.of(tx, merchant.getName());
     }
+
+    @Transactional
+    public PaymentResult cancelPayment(PaymentCommand.Cancel command) {
+        var userId = UserContextHolder.getUserId();
+        PaymentTransaction tx = paymentTransactionService.getByTxNo(command.txNo());
+        tx.cancel();
+
+        walletService.validateWalletAccess(tx.getWalletId(), userId);
+        var merchant = merchantService.getMerchantById(tx.getMerchantId());
+        return PaymentResult.of(tx, merchant.getName());
+    }
 }

--- a/src/main/java/com/lemonpay/payment/application/PaymentUseCase.java
+++ b/src/main/java/com/lemonpay/payment/application/PaymentUseCase.java
@@ -28,18 +28,20 @@ public class PaymentUseCase {
 
     @Transactional
     public PaymentResult createPendingPayment(PaymentCommand.Create command) {
-        merchantService.validateMerchantPayable(command.merchantId());
-        var merchant = merchantService.getMerchantById(command.merchantId());
-
-        walletService.validateWalletAccess(command.walletId(), UserContextHolder.getUserId());
+        var userId = UserContextHolder.getUserId();
+        walletService.validateWalletAccess(command.walletId(), userId);
+        var merchant = merchantService.getPayableMerchant(command.merchantId());
 
         String txNo = txNoGenerator.generate();
+        Money paymentAmount = Money.of(command.amount(), command.currency());
+        Money settlementAmount = Money.of(command.settlementAmount(), command.settlementCurrency());
+
         var result = paymentTransactionService.createPending(
                 txNo,
                 command.walletId(),
                 command.merchantId(),
-                Money.of(command.amount(), command.currency()),
-                Money.of(command.settlementAmount(), command.settlementCurrency()),
+                paymentAmount,
+                settlementAmount,
                 command.exchangeRate(),
                 command.idempotencyKey(),
                 command.orderId()
@@ -50,51 +52,51 @@ public class PaymentUseCase {
 
     @Transactional
     public PaymentResult approvePayment(PaymentCommand.Approve command) {
-        var userId = UserContextHolder.getUserId();
-
-        PaymentTransaction tx = paymentTransactionService.getByTxNo(command.txNo());
-
-        walletService.validateWalletAccess(tx.getWalletId(), userId);
-        merchantService.validateMerchantPayable(tx.getMerchantId());
-        var merchant = merchantService.getMerchantById(tx.getMerchantId());
-
+        PaymentTransaction tx = getOwnedPaymentTransaction(command.txNo());
+        var merchant = merchantService.getPayableMerchant(tx.getMerchantId());
         paymentTransactionService.validateCompletable(tx);
-        Money paymentAmount = Money.of(tx.getAmount(), tx.getCurrency());
-        WalletBalance balance = walletBalanceService.getWalletBalance(tx.getWalletId(), tx.getCurrency());
-
-        balance.decrease(paymentAmount);
-
-        LedgerEntry ledgerEntry = LedgerEntry.of(
-                tx.getWalletId(),
-                paymentAmount,
-                balance.toMoney(),
-                EntryType.PAYMENT
-        );
-        ledgerEntryRepository.save(ledgerEntry);
-
+        var balance = debitPaymentAmount(tx);
+        recordPaymentLedger(tx, balance);
         tx.complete();
         return PaymentResult.of(tx, merchant.getName());
     }
 
     @Transactional(readOnly = true)
     public PaymentResult getDetail(PaymentCommand.Query command) {
-        var userId = UserContextHolder.getUserId();
-
-        PaymentTransaction tx = paymentTransactionService.getByTxNo(command.txNo());
-        walletService.validateWalletAccess(tx.getWalletId(), userId);
+        PaymentTransaction tx = getOwnedPaymentTransaction(command.txNo());
         var merchant = merchantService.getMerchantById(tx.getMerchantId());
-
         return PaymentResult.of(tx, merchant.getName());
     }
 
     @Transactional
     public PaymentResult cancelPayment(PaymentCommand.Cancel command) {
-        var userId = UserContextHolder.getUserId();
-        PaymentTransaction tx = paymentTransactionService.getByTxNo(command.txNo());
+        PaymentTransaction tx = getOwnedPaymentTransaction(command.txNo());
         tx.cancel();
-
-        walletService.validateWalletAccess(tx.getWalletId(), userId);
         var merchant = merchantService.getMerchantById(tx.getMerchantId());
         return PaymentResult.of(tx, merchant.getName());
+    }
+
+    private PaymentTransaction getOwnedPaymentTransaction(String txNo) {
+        var userId = UserContextHolder.getUserId();
+        PaymentTransaction tx = paymentTransactionService.getByTxNo(txNo);
+        walletService.validateWalletAccess(tx.getWalletId(), userId);
+        return tx;
+    }
+
+    private WalletBalance debitPaymentAmount(PaymentTransaction tx) {
+        Money paymentAmount = tx.toPaymentMoney();
+        WalletBalance balance = walletBalanceService.getWalletBalance(tx.getWalletId(), tx.getCurrency());
+        balance.decrease(paymentAmount);
+        return balance;
+    }
+
+    private void recordPaymentLedger(PaymentTransaction tx, WalletBalance balance) {
+        LedgerEntry ledgerEntry = LedgerEntry.of(
+                tx.getWalletId(),
+                tx.toPaymentMoney(),
+                balance.toMoney(),
+                EntryType.PAYMENT
+        );
+        ledgerEntryRepository.save(ledgerEntry);
     }
 }

--- a/src/main/java/com/lemonpay/payment/application/PaymentUseCase.java
+++ b/src/main/java/com/lemonpay/payment/application/PaymentUseCase.java
@@ -1,0 +1,89 @@
+package com.lemonpay.payment.application;
+
+import com.lemonpay.common.auth.UserContextHolder;
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.ledger.domain.EntryType;
+import com.lemonpay.ledger.domain.LedgerEntry;
+import com.lemonpay.ledger.domain.LedgerEntryRepository;
+import com.lemonpay.merchant.domain.MerchantService;
+import com.lemonpay.payment.domain.PaymentTransaction;
+import com.lemonpay.payment.domain.PaymentTransactionService;
+import com.lemonpay.wallet.domain.WalletBalance;
+import com.lemonpay.wallet.domain.WalletBalanceService;
+import com.lemonpay.wallet.domain.WalletService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentUseCase {
+
+    private final PaymentTransactionService paymentTransactionService;
+    private final MerchantService merchantService;
+    private final LedgerEntryRepository ledgerEntryRepository;
+    private final WalletService walletService;
+    private final PaymentTxNoGenerator txNoGenerator;
+    private final WalletBalanceService walletBalanceService;
+
+    @Transactional
+    public PaymentResult createPendingPayment(PaymentCommand.Create command) {
+        merchantService.validateMerchantPayable(command.merchantId());
+        var merchant = merchantService.getMerchantById(command.merchantId());
+
+        walletService.validateWalletAccess(command.walletId(), UserContextHolder.getUserId());
+
+        String txNo = txNoGenerator.generate();
+        var result = paymentTransactionService.createPending(
+                txNo,
+                command.walletId(),
+                command.merchantId(),
+                Money.of(command.amount(), command.currency()),
+                Money.of(command.settlementAmount(), command.settlementCurrency()),
+                command.exchangeRate(),
+                command.idempotencyKey(),
+                command.orderId()
+        );
+
+        return PaymentResult.of(result, merchant.getName());
+    }
+
+    @Transactional
+    public PaymentResult approvePayment(PaymentCommand.Approve command) {
+        var userId = UserContextHolder.getUserId();
+
+        PaymentTransaction tx = paymentTransactionService.getByTxNo(command.txNo());
+
+        walletService.validateWalletAccess(tx.getWalletId(), userId);
+        merchantService.validateMerchantPayable(tx.getMerchantId());
+        var merchant = merchantService.getMerchantById(tx.getMerchantId());
+
+        paymentTransactionService.validateCompletable(tx);
+        Money paymentAmount = Money.of(tx.getAmount(), tx.getCurrency());
+        WalletBalance balance = walletBalanceService.getWalletBalance(tx.getWalletId(), tx.getCurrency());
+
+        balance.decrease(paymentAmount);
+
+        LedgerEntry ledgerEntry = LedgerEntry.of(
+                tx.getWalletId(),
+                paymentAmount,
+                balance.toMoney(),
+                EntryType.PAYMENT
+        );
+        ledgerEntryRepository.save(ledgerEntry);
+
+        tx.complete();
+        return PaymentResult.of(tx, merchant.getName());
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentResult getDetail(PaymentCommand.Query command) {
+        var userId = UserContextHolder.getUserId();
+
+        PaymentTransaction tx = paymentTransactionService.getByTxNo(command.txNo());
+        walletService.validateWalletAccess(tx.getWalletId(), userId);
+        var merchant = merchantService.getMerchantById(tx.getMerchantId());
+
+        return PaymentResult.of(tx, merchant.getName());
+    }
+}

--- a/src/main/java/com/lemonpay/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/lemonpay/payment/domain/PaymentStatus.java
@@ -1,8 +1,59 @@
 package com.lemonpay.payment.domain;
 
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum PaymentStatus {
-    PENDING,    // 대기
-    COMPLETED,  // 완료
-    FAILED,     // 실패
-    CANCELLED   // 취소
+    /**
+     * 대기
+     */
+    PENDING {
+        @Override
+        public Set<PaymentStatus> allowedTransitions() {
+            return EnumSet.of(COMPLETED, FAILED, CANCELLED);
+        }
+    },
+    /**
+     * 완료
+     */
+    COMPLETED {
+        @Override
+        public Set<PaymentStatus> allowedTransitions() {
+            return EnumSet.noneOf(PaymentStatus.class);
+        }
+    },
+    /**
+     * 실패
+     */
+    FAILED {
+        @Override
+        public Set<PaymentStatus> allowedTransitions() {
+            return EnumSet.noneOf(PaymentStatus.class);
+        }
+    },
+    /**
+     * 요청 취소
+     */
+    CANCELLED {
+        @Override
+        public Set<PaymentStatus> allowedTransitions() {
+            return EnumSet.noneOf(PaymentStatus.class);
+        }
+    };
+
+    public abstract Set<PaymentStatus> allowedTransitions();
+
+    public boolean canTransitionTo(PaymentStatus next) { return allowedTransitions().contains(next); }
+
+    public void validateTransition(PaymentStatus next) {
+        if(!canTransitionTo(next)) {
+            throw new CoreException(
+                    ErrorType.INVALID_STATE_TRANSITION,
+                    "결제 내역 상태 전이 불가 : %s -> %s".formatted(this.name(), next.name())
+            );
+        }
+    }
 }

--- a/src/main/java/com/lemonpay/payment/domain/PaymentTransaction.java
+++ b/src/main/java/com/lemonpay/payment/domain/PaymentTransaction.java
@@ -1,0 +1,134 @@
+package com.lemonpay.payment.domain;
+
+import com.lemonpay.common.domain.BaseEntity;
+import com.lemonpay.common.domain.Currency;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payment_transactions",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_transactions_tx_no",
+                        columnNames = "tx_no"
+                ),
+                @UniqueConstraint(name = "uk_payment_transactions_merchant_idempotency",
+                        columnNames = {"merchant_id", "idempotency_key"}
+                )
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentTransaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // AUTO_INCREMENT, 내부 전용
+
+    @Column(name = "tx_no", nullable = false, updatable = false, length = 18)
+    private String txNo; // 거래일련번호: yyyyMMdd + 10자리 순번
+
+    @Column(name = "amount", nullable = false, precision = 18, scale = 4)
+    private BigDecimal amount; // 결제 금액
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "currency", nullable = false, length = 3)
+    private Currency currency; // 결제 통화
+
+    @Column(name = "settlement_amount", nullable = false, precision = 18, scale = 4)
+    private BigDecimal settlementAmount; // 실제 결제 통화 (KRW | USD| JPY)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "settlement_currency", nullable = false, length = 3)
+    private Currency settlementCurrency; // 실제 차감 통화 e.g) KRW
+
+    @Column(name = "exchange_rate", nullable = false, precision = 18, scale = 4)
+    private BigDecimal exchangeRate; // 적용 환율
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private PaymentStatus status; // 결제 상태 PENDING | COMPLETED | FAILED | CANCELLED
+
+    @Column(name = "idempotency_key", nullable = false, updatable = false, length = 100)
+    private String idempotencyKey; // 중복 결제 방지
+
+    @Column(name = "wallet_id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    private UUID walletId; // Wallet.id 참조. 지갑 ID
+
+    @Column(name = "merchant_id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    private UUID merchantId; // Merchant.id 참조. 가맹점 ID
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt; // 결제 완료 시각, nullable
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt; // 결제 완료 시각, nullable
+
+    private PaymentTransaction(
+            String txNo,
+            UUID walletId,
+            UUID merchantId,
+            BigDecimal amount,
+            Currency currency,
+            BigDecimal settlementAmount,
+            Currency settlementCurrency,
+            BigDecimal exchangeRate,
+            String idempotencyKey
+    ) {
+        this.txNo = txNo;
+        this.walletId = walletId;
+        this.merchantId = merchantId;
+        this.amount = amount;
+        this.currency = currency;
+        this.settlementAmount = settlementAmount;
+        this.settlementCurrency = settlementCurrency;
+        this.exchangeRate = exchangeRate;
+        this.idempotencyKey = idempotencyKey;
+        this.status = PaymentStatus.PENDING;
+    }
+
+    public static PaymentTransaction create(
+            String txNo,
+            UUID walletId,
+            UUID merchantId,
+            BigDecimal amount,
+            Currency currency,
+            BigDecimal settlementAmount,
+            Currency settlementCurrency,
+            BigDecimal exchangeRate,
+            String idempotencyKey
+    ) {
+        return new PaymentTransaction(
+                txNo,
+                walletId,
+                merchantId,
+                amount,
+                currency,
+                settlementAmount,
+                settlementCurrency,
+                exchangeRate,
+                idempotencyKey
+        );
+    }
+
+    public void cancel() {
+        this.status.validateTransition(PaymentStatus.CANCELLED);
+        this.status = PaymentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    public void complete() {
+        this.status.validateTransition(PaymentStatus.COMPLETED);
+        this.status = PaymentStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void failed() {
+        this.status.validateTransition(PaymentStatus.FAILED);
+        this.status = PaymentStatus.FAILED;
+    }
+}

--- a/src/main/java/com/lemonpay/payment/domain/PaymentTransaction.java
+++ b/src/main/java/com/lemonpay/payment/domain/PaymentTransaction.java
@@ -56,6 +56,9 @@ public class PaymentTransaction extends BaseEntity {
     @Column(name = "idempotency_key", nullable = false, updatable = false, length = 100)
     private String idempotencyKey; // 중복 결제 방지
 
+    @Column(name = "order_id", nullable = true, length = 100)
+    private String orderId;
+
     @Column(name = "wallet_id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
     private UUID walletId; // Wallet.id 참조. 지갑 ID
 
@@ -77,7 +80,8 @@ public class PaymentTransaction extends BaseEntity {
             BigDecimal settlementAmount,
             Currency settlementCurrency,
             BigDecimal exchangeRate,
-            String idempotencyKey
+            String idempotencyKey,
+            String orderId
     ) {
         this.txNo = txNo;
         this.walletId = walletId;
@@ -89,6 +93,7 @@ public class PaymentTransaction extends BaseEntity {
         this.exchangeRate = exchangeRate;
         this.idempotencyKey = idempotencyKey;
         this.status = PaymentStatus.PENDING;
+        this.orderId = orderId;
     }
 
     public static PaymentTransaction create(
@@ -100,7 +105,8 @@ public class PaymentTransaction extends BaseEntity {
             BigDecimal settlementAmount,
             Currency settlementCurrency,
             BigDecimal exchangeRate,
-            String idempotencyKey
+            String idempotencyKey,
+            String orderId
     ) {
         return new PaymentTransaction(
                 txNo,
@@ -111,7 +117,8 @@ public class PaymentTransaction extends BaseEntity {
                 settlementAmount,
                 settlementCurrency,
                 exchangeRate,
-                idempotencyKey
+                idempotencyKey,
+                orderId
         );
     }
 

--- a/src/main/java/com/lemonpay/payment/domain/PaymentTransaction.java
+++ b/src/main/java/com/lemonpay/payment/domain/PaymentTransaction.java
@@ -2,6 +2,7 @@ package com.lemonpay.payment.domain;
 
 import com.lemonpay.common.domain.BaseEntity;
 import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -137,5 +138,9 @@ public class PaymentTransaction extends BaseEntity {
     public void failed() {
         this.status.validateTransition(PaymentStatus.FAILED);
         this.status = PaymentStatus.FAILED;
+    }
+
+    public Money toPaymentMoney() {
+        return Money.of(amount, currency);
     }
 }

--- a/src/main/java/com/lemonpay/payment/domain/PaymentTransactionRepository.java
+++ b/src/main/java/com/lemonpay/payment/domain/PaymentTransactionRepository.java
@@ -1,0 +1,11 @@
+package com.lemonpay.payment.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentTransactionRepository {
+    PaymentTransaction save(PaymentTransaction paymentTransaction);
+    Optional<PaymentTransaction> findByTxNo(String txNo);
+    Optional<PaymentTransaction> findByMerchantIdAndIdempotencyKey(UUID merchantId, String idempotencyKey);
+    boolean existsByTxNo(String txNo);
+}

--- a/src/main/java/com/lemonpay/payment/domain/PaymentTransactionService.java
+++ b/src/main/java/com/lemonpay/payment/domain/PaymentTransactionService.java
@@ -1,0 +1,102 @@
+package com.lemonpay.payment.domain;
+
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentTransactionService {
+
+    private final PaymentTransactionRepository paymentTransactionRepository;
+
+    @Transactional
+    public PaymentTransaction createPending(String txNo,
+                                            UUID walletId,
+                                            UUID merchantId,
+                                            Money paymentAmount,
+                                            Money settlementAmount,
+                                            BigDecimal exchangeRate,
+                                            String idempotencyKey,
+                                            String orderId) {
+        return paymentTransactionRepository
+                .findByMerchantIdAndIdempotencyKey(merchantId, idempotencyKey)
+                .orElseGet(() -> createNewPending(
+                        txNo,
+                        walletId,
+                        merchantId,
+                        paymentAmount,
+                        settlementAmount,
+                        exchangeRate,
+                        idempotencyKey,
+                        orderId
+                ));
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentTransaction getByTxNo(String txNo) {
+        return paymentTransactionRepository.findByTxNo(txNo)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "결제 내역을 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public PaymentTransaction complete(String txNo) {
+        PaymentTransaction paymentTransaction = getByTxNo(txNo);
+        paymentTransaction.complete();
+        return paymentTransactionRepository.save(paymentTransaction);
+    }
+
+    @Transactional
+    public PaymentTransaction cancel(String txNo) {
+        PaymentTransaction paymentTransaction = getByTxNo(txNo);
+        paymentTransaction.cancel();
+        return paymentTransactionRepository.save(paymentTransaction);
+    }
+
+    @Transactional
+    public PaymentTransaction fail(String txNo) {
+        PaymentTransaction paymentTransaction = getByTxNo(txNo);
+        paymentTransaction.failed();
+        return paymentTransactionRepository.save(paymentTransaction);
+    }
+
+    @Transactional(readOnly = true)
+    public void validateCompletable(PaymentTransaction paymentTransaction) {
+        paymentTransaction.getStatus().validateTransition(PaymentStatus.COMPLETED);
+    }
+
+    private PaymentTransaction createNewPending(String txNo,
+                                                UUID walletId,
+                                                UUID merchantId,
+                                                Money paymentAmount,
+                                                Money settlementAmount,
+                                                BigDecimal exchangeRate,
+                                                String idempotencyKey,
+                                                String orderId) {
+
+        if(paymentTransactionRepository.existsByTxNo(txNo)) {
+            throw new CoreException(ErrorType.INVALID_REQUEST, "이미 존재하는 결재 번호 입니다. 다시 확인해주세요.");
+        }
+
+        PaymentTransaction paymentTransaction = PaymentTransaction.create(
+                txNo,
+                walletId,
+                merchantId,
+                paymentAmount.amount(),
+                paymentAmount.currency(),
+                settlementAmount.amount(),
+                settlementAmount.currency(),
+                exchangeRate,
+                idempotencyKey,
+                orderId
+        );
+
+        return paymentTransactionRepository.save(paymentTransaction);
+    }
+}

--- a/src/main/java/com/lemonpay/payment/domain/PaymentTxNoSequence.java
+++ b/src/main/java/com/lemonpay/payment/domain/PaymentTxNoSequence.java
@@ -1,0 +1,38 @@
+package com.lemonpay.payment.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "payment_tx_no_sequence")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentTxNoSequence {
+
+    @Id
+    @Column(name = "sequence_date", nullable = false, length = 8)
+    private String sequenceDate;
+
+    @Column(name = "next_value", nullable = false)
+    private Long nextValue;
+
+    private PaymentTxNoSequence(String sequenceDate) {
+        this.sequenceDate = sequenceDate;
+        this.nextValue = 1L;
+    }
+
+    public static PaymentTxNoSequence create(String sequenceDate) {
+        return new PaymentTxNoSequence(sequenceDate);
+    }
+
+    public Long issue() {
+        Long issued = this.nextValue;
+        this.nextValue++;
+        return issued;
+    }
+}

--- a/src/main/java/com/lemonpay/payment/infrastructure/PaymentTransactionJpaRepository.java
+++ b/src/main/java/com/lemonpay/payment/infrastructure/PaymentTransactionJpaRepository.java
@@ -1,0 +1,15 @@
+package com.lemonpay.payment.infrastructure;
+
+import com.lemonpay.payment.domain.PaymentTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentTransactionJpaRepository extends JpaRepository<PaymentTransaction, Long> {
+    Optional<PaymentTransaction> findByTxNo(String txNo);
+
+    Optional<PaymentTransaction> findByMerchantIdAndIdempotencyKey(UUID merchantId, String idempotencyKey);
+
+    boolean existsByTxNo(String txNo);
+}

--- a/src/main/java/com/lemonpay/payment/infrastructure/PaymentTransactionRepositoryImpl.java
+++ b/src/main/java/com/lemonpay/payment/infrastructure/PaymentTransactionRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.lemonpay.payment.infrastructure;
+
+import com.lemonpay.payment.domain.PaymentTransaction;
+import com.lemonpay.payment.domain.PaymentTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+
+@Component
+@RequiredArgsConstructor
+public class PaymentTransactionRepositoryImpl implements PaymentTransactionRepository {
+    private final PaymentTransactionJpaRepository jpaRepository;
+
+    @Override
+    public PaymentTransaction save(PaymentTransaction paymentTransaction) {
+        return jpaRepository.save(paymentTransaction);
+    }
+
+    @Override
+    public Optional<PaymentTransaction> findByTxNo(String txNo) {
+        return jpaRepository.findByTxNo((txNo));
+    }
+
+    @Override
+    public Optional<PaymentTransaction> findByMerchantIdAndIdempotencyKey(UUID merchantId, String idempotencyKey) {
+        return jpaRepository.findByMerchantIdAndIdempotencyKey(merchantId, idempotencyKey);
+    }
+
+    @Override
+    public boolean existsByTxNo(String txNo) {
+        return jpaRepository.existsByTxNo(txNo);
+    }
+}

--- a/src/main/java/com/lemonpay/payment/infrastructure/PaymentTxNoSequenceJpaRepository.java
+++ b/src/main/java/com/lemonpay/payment/infrastructure/PaymentTxNoSequenceJpaRepository.java
@@ -1,0 +1,17 @@
+package com.lemonpay.payment.infrastructure;
+
+import com.lemonpay.payment.domain.PaymentTxNoSequence;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface PaymentTxNoSequenceJpaRepository extends JpaRepository<PaymentTxNoSequence, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from PaymentTxNoSequence s where s.sequenceDate = :sequenceDate")
+    Optional<PaymentTxNoSequence> findBySequenceDateForUpdate(@Param("sequenceDate") String sequenceDate);
+}

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentDto.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentDto.java
@@ -1,0 +1,83 @@
+package com.lemonpay.payment.interfaces.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "결제 API 요청 및 응답 DTO")
+public class PaymentDto {
+
+    @Schema(description = "결제 세션 생성 요청")
+    public record CreationRequest (
+        @NotNull UUID walletId,
+        @NotNull UUID merchantId,
+        @NotBlank String currency,
+        @NotNull @Positive BigDecimal amount,
+        @NotBlank String orderId,
+        @NotBlank String idempotencyKey
+    ) {
+
+    }
+
+    @Schema(description = "결제 세션 생성 응답 - 소비자가 승인 전 확인할 예상 금액 포함")
+    public record CreationResponse (
+        UUID paymentId,
+        String merchantName,
+        BigDecimal amount,
+        String currency,
+        // TODO: 다통화 결제 구현 시 estimatedKrwAmount/exchangeRate/rateSource 응답 필드 확정
+        String orderId,
+        LocalDateTime createdAt
+    ) {
+
+    }
+
+    @Schema(description = "결제 승인 요청 - MVP 범위에서는 별도의 body 없이 X-USER-ID와 paymentId로 승인 처리")
+    public record ApproveRequest () { }
+
+    @Schema(description = "결제 승인 응답")
+    public record ApproveResponse (
+        UUID paymentId,
+        String status,
+        BigDecimal amount,
+        String currency,
+        // TODO: 가맹점 정산 배치 구현 시 settledAmount / settledCurrency 응답 필드 확정
+        // TODO: 다통화 결제 구현 시 exchangeRate/rateSource 응답 필드 확정
+        LocalDateTime completedAt
+    ) {
+
+    }
+
+    @Schema(description = "결제 취소 요청")
+    public record CancelRequest (
+    ) { }
+
+    @Schema(description = "결제 취소 응답")
+    public record CancelResponse(
+            UUID paymentId,
+            String status,
+            LocalDateTime cancelledAt
+    ) { }
+
+    @Schema(description = "결제 상세 조회 응답")
+    public record DetailViewResponse(
+            UUID paymentId,
+            String status,
+            String merchantName,
+            BigDecimal amount,
+            String currency,
+            // TODO: 가맹점 정산 배치 구현 시 settledAmount / settledCurrency 응답 필드 확정
+            // TODO: 다통화 결제 구현 시 exchangeRate/rateSource 응답 필드 확정
+            String orderId,
+            LocalDateTime createdAt,
+            LocalDateTime completedAt,
+            LocalDateTime cancelledAt
+    ) {
+
+    }
+}

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentDto.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentDto.java
@@ -1,5 +1,8 @@
 package com.lemonpay.payment.interfaces.api;
 
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.payment.application.PaymentCommand;
+import com.lemonpay.payment.application.PaymentResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -13,71 +16,95 @@ import java.util.UUID;
 public class PaymentDto {
 
     @Schema(description = "결제 세션 생성 요청")
-    public record CreationRequest (
-        @NotNull UUID walletId,
-        @NotNull UUID merchantId,
-        @NotBlank String currency,
-        @NotNull @Positive BigDecimal amount,
-        @NotBlank String orderId,
-        @NotBlank String idempotencyKey
+    public record CreationRequest(
+            @NotNull UUID walletId,
+            @NotNull UUID merchantId,
+            @NotBlank String currency,
+            @NotNull @Positive BigDecimal amount,
+            @NotBlank String orderId,
+            @NotBlank String idempotencyKey
     ) {
-
-    }
-
-    @Schema(description = "결제 세션 생성 응답 - 소비자가 승인 전 확인할 예상 금액 포함")
-    public record CreationResponse (
-        UUID paymentId,
-        String merchantName,
-        BigDecimal amount,
-        String currency,
-        // TODO: 다통화 결제 구현 시 estimatedKrwAmount/exchangeRate/rateSource 응답 필드 확정
-        String orderId,
-        LocalDateTime createdAt
-    ) {
-
+        public PaymentCommand.Create toCommand() {
+            Currency parsedCurrency = Currency.valueOf(currency());
+            return new PaymentCommand.Create(
+                    walletId(),
+                    merchantId(),
+                    parsedCurrency,
+                    amount(),
+                    parsedCurrency, // TODO
+                    amount(), // TODO
+                    BigDecimal.ZERO,
+                    orderId(),
+                    idempotencyKey()
+            );
+        }
     }
 
     @Schema(description = "결제 승인 요청 - MVP 범위에서는 별도의 body 없이 X-USER-ID와 paymentId로 승인 처리")
-    public record ApproveRequest () { }
-
-    @Schema(description = "결제 승인 응답")
-    public record ApproveResponse (
-        UUID paymentId,
-        String status,
-        BigDecimal amount,
-        String currency,
-        // TODO: 가맹점 정산 배치 구현 시 settledAmount / settledCurrency 응답 필드 확정
-        // TODO: 다통화 결제 구현 시 exchangeRate/rateSource 응답 필드 확정
-        LocalDateTime completedAt
-    ) {
-
+    public record ApproveRequest() {
     }
 
     @Schema(description = "결제 취소 요청")
-    public record CancelRequest (
+    public record CancelRequest(
     ) { }
 
-    @Schema(description = "결제 취소 응답")
-    public record CancelResponse(
-            UUID paymentId,
-            String status,
-            LocalDateTime cancelledAt
-    ) { }
+    @Schema(description = "결제 거래 응답")
+    public record PaymentResponse(
+            @Schema(description = "레몬페이 결제 거래번호", example = "202601010000000001")
+            String txNo,
 
-    @Schema(description = "결제 상세 조회 응답")
-    public record DetailViewResponse(
-            UUID paymentId,
+            @Schema(description = "결제 상태", example = "PENDING")
             String status,
+
+            @Schema(description = "지갑 ID")
+            UUID walletId,
+
+            @Schema(description = "가맹점 ID")
+            UUID merchantId,
+
+            @Schema(description = "가맹점명", example = "테스트 가맹점")
             String merchantName,
+
+            @Schema(description = "결제 금액", example = "10000.0000")
             BigDecimal amount,
+
+            @Schema(description = "결제 통화", example = "KRW")
             String currency,
-            // TODO: 가맹점 정산 배치 구현 시 settledAmount / settledCurrency 응답 필드 확정
-            // TODO: 다통화 결제 구현 시 exchangeRate/rateSource 응답 필드 확정
-            String orderId,
+
+            @Schema(description = "정산 금액", example = "10000.0000")
+            BigDecimal settlementAmount,
+
+            @Schema(description = "정산 통화", example = "KRW")
+            String settlementCurrency,
+
+            @Schema(description = "적용 환율", example = "1.0000")
+            BigDecimal exchangeRate,
+
+            @Schema(description = "결제 요청 생성 시각")
             LocalDateTime createdAt,
+
+            @Schema(description = "결제 요청 완료 시각, 완료 전이면 null")
             LocalDateTime completedAt,
+
+            @Schema(description = "결제 요청 취소 시각, 취소 전이면 null")
             LocalDateTime cancelledAt
     ) {
-
+        public static PaymentDto.PaymentResponse from(PaymentResult result) {
+            return new PaymentDto.PaymentResponse(
+                    result.txNo(),
+                    result.status(),
+                    result.walletId(),
+                    result.merchantId(),
+                    result.merchantName(),
+                    result.amount(),
+                    result.currency(),
+                    result.settlementAmount(),
+                    result.settlementCurrency(),
+                    result.exchangeRate(),
+                    result.createdAt(),
+                    result.completedAt(),
+                    result.cancelledAt()
+            );
+        }
     }
 }

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1ApiSpec.java
@@ -10,8 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.UUID;
-
 @Tag(name = "Payment V1 API Specification")
 public interface PaymentV1ApiSpec {
 
@@ -20,37 +18,37 @@ public interface PaymentV1ApiSpec {
             summary = "가맹점 결제 요청 생성 API",
             description = "가맹점 클라이언트에서 레몬페이로 결제 요청 생성"
     )
-    ResponseEntity<PaymentDto.CreationResponse> create(
+    ResponseEntity<PaymentDto.PaymentResponse> create(
             @Valid @RequestBody PaymentDto.CreationRequest request
     );
 
-    @PostMapping("/{paymentId}/approve")
+    @PostMapping("/{txNo}/approve")
     @Operation(
             summary = "결제 승인 API",
             description = "레몬페이 잔액 차감 및 결제 승인을 처리"
     )
-    ResponseEntity<PaymentDto.ApproveResponse> approve(
+    ResponseEntity<PaymentDto.PaymentResponse> approve(
             @Parameter(description = "결제 ID", required = true)
-            @PathVariable("paymentId") UUID paymentId
+            @PathVariable("txNo") String txNo
     );
 
-    @PostMapping("/{paymentId}/cancel")
+    @PostMapping("/{txNo}/cancel")
     @Operation(
             summary = "결제 취소 API",
             description = "레몬페이 결제 취소 처리"
     )
-    ResponseEntity<PaymentDto.CancelResponse> cancel(
+    ResponseEntity<PaymentDto.PaymentResponse> cancel(
             @Parameter(description = "결제 ID", required = true)
-            @PathVariable("paymentId") UUID paymentId
+            @PathVariable("txNo") String txNo
     );
 
-    @GetMapping("/{paymentId}")
+    @GetMapping("/{txNo}")
     @Operation(
             summary = "결제 내역 조회 API",
             description = "결제 ID에 대한 세부 내역 정보 응답"
     )
-    ResponseEntity<PaymentDto.DetailViewResponse> detail(
+    ResponseEntity<PaymentDto.PaymentResponse> detail(
             @Parameter(description = "결제 ID", required = true)
-            @PathVariable("paymentId") UUID paymentId
+            @PathVariable("txNo") String txNo
     );
 }

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1ApiSpec.java
@@ -1,0 +1,56 @@
+package com.lemonpay.payment.interfaces.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@Tag(name = "Payment V1 API Specification")
+public interface PaymentV1ApiSpec {
+
+    @PostMapping
+    @Operation(
+            summary = "가맹점 결제 요청 생성 API",
+            description = "가맹점 클라이언트에서 레몬페이로 결제 요청 생성"
+    )
+    ResponseEntity<PaymentDto.CreationResponse> create(
+            @Valid @RequestBody PaymentDto.CreationRequest request
+    );
+
+    @PostMapping("/{paymentId}/approve")
+    @Operation(
+            summary = "결제 승인 API",
+            description = "레몬페이 잔액 차감 및 결제 승인을 처리"
+    )
+    ResponseEntity<PaymentDto.ApproveResponse> approve(
+            @Parameter(description = "결제 ID", required = true)
+            @PathVariable("paymentId") UUID paymentId
+    );
+
+    @PostMapping("/{paymentId}/cancel")
+    @Operation(
+            summary = "결제 취소 API",
+            description = "레몬페이 결제 취소 처리"
+    )
+    ResponseEntity<PaymentDto.CancelResponse> cancel(
+            @Parameter(description = "결제 ID", required = true)
+            @PathVariable("paymentId") UUID paymentId
+    );
+
+    @GetMapping("/{paymentId}")
+    @Operation(
+            summary = "결제 내역 조회 API",
+            description = "결제 ID에 대한 세부 내역 정보 응답"
+    )
+    ResponseEntity<PaymentDto.DetailViewResponse> detail(
+            @Parameter(description = "결제 ID", required = true)
+            @PathVariable("paymentId") UUID paymentId
+    );
+}

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1Controller.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1Controller.java
@@ -31,7 +31,9 @@ public class PaymentV1Controller implements PaymentV1ApiSpec {
 
     @Override
     public ResponseEntity<PaymentDto.PaymentResponse> cancel(String txNo) {
-        return null;
+        var command = new PaymentCommand.Cancel(txNo);
+        var result = paymentUseCase.cancelPayment(command);
+        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
     }
 
     @Override

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1Controller.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1Controller.java
@@ -1,0 +1,43 @@
+package com.lemonpay.payment.interfaces.api;
+
+import com.lemonpay.payment.application.PaymentCommand;
+import com.lemonpay.payment.application.PaymentUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentV1Controller implements PaymentV1ApiSpec {
+
+    private final PaymentUseCase paymentUseCase;
+
+    @Override
+    public ResponseEntity<PaymentDto.PaymentResponse> create(PaymentDto.CreationRequest request) {
+        var result = paymentUseCase.createPendingPayment(request.toCommand());
+        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
+    }
+
+    @Override
+    public ResponseEntity<PaymentDto.PaymentResponse> approve(String txNo) {
+        var command = new PaymentCommand.Approve(txNo);
+        var result = paymentUseCase.approvePayment(command);
+        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
+    }
+
+    @Override
+    public ResponseEntity<PaymentDto.PaymentResponse> cancel(String txNo) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<PaymentDto.PaymentResponse> detail(String txNo) {
+        var command = new PaymentCommand.Query(txNo);
+        var result = paymentUseCase.getDetail(command);
+        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
+    }
+}

--- a/src/test/java/com/lemonpay/payment/application/PaymentTxNoGeneratorTest.java
+++ b/src/test/java/com/lemonpay/payment/application/PaymentTxNoGeneratorTest.java
@@ -1,0 +1,44 @@
+package com.lemonpay.payment.application;
+
+import com.lemonpay.payment.domain.PaymentTxNoSequence;
+import com.lemonpay.payment.infrastructure.PaymentTxNoSequenceJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PaymentTxNoGeneratorTest {
+
+    @Autowired
+    private PaymentTxNoGenerator paymentTxNoGenerator;
+
+    @Autowired
+    private PaymentTxNoSequenceJpaRepository repository;
+
+    @Test
+    @DisplayName("결제 거래번호는 yyyyMMdd와 10자리 순번으로 생성된다.")
+    void generate_thenReturnDateAndTenDigitSequence() {
+        // given
+        String today = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+        repository.deleteById(today);
+
+        // when
+        String firstTxNo = paymentTxNoGenerator.generate();
+        String secondTxNo = paymentTxNoGenerator.generate();
+
+        // then
+        assertThat(firstTxNo).isEqualTo(today + "0000000001");
+        assertThat(secondTxNo).isEqualTo(today + "0000000002");
+        assertThat(firstTxNo).hasSize(18);
+        assertThat(secondTxNo).hasSize(18);
+
+        PaymentTxNoSequence sequence = repository.findById(today).orElseThrow();
+        assertThat(sequence.getNextValue()).isEqualTo(3L);
+    }
+}

--- a/src/test/java/com/lemonpay/payment/application/PaymentUseCaseConcurrencyTest.java
+++ b/src/test/java/com/lemonpay/payment/application/PaymentUseCaseConcurrencyTest.java
@@ -1,0 +1,182 @@
+package com.lemonpay.payment.application;
+
+import com.lemonpay.common.auth.UserContext;
+import com.lemonpay.common.auth.UserContextHolder;
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.ledger.domain.EntryType;
+import com.lemonpay.ledger.domain.LedgerEntry;
+import com.lemonpay.ledger.domain.LedgerEntryRepository;
+import com.lemonpay.member.domain.Member;
+import com.lemonpay.member.domain.MemberRepository;
+import com.lemonpay.merchant.domain.Merchant;
+import com.lemonpay.merchant.domain.MerchantRepository;
+import com.lemonpay.payment.domain.PaymentStatus;
+import com.lemonpay.payment.domain.PaymentTransaction;
+import com.lemonpay.payment.domain.PaymentTransactionRepository;
+import com.lemonpay.wallet.domain.Wallet;
+import com.lemonpay.wallet.domain.WalletBalance;
+import com.lemonpay.wallet.domain.WalletBalanceRepository;
+import com.lemonpay.wallet.domain.WalletRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.math.BigDecimal;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PaymentUseCaseConcurrencyTest {
+
+    @Autowired private PaymentUseCase paymentUseCase;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private WalletBalanceRepository walletBalanceRepository;
+    @Autowired private MerchantRepository merchantRepository;
+    @Autowired private PaymentTransactionRepository paymentTransactionRepository;
+    @Autowired private LedgerEntryRepository ledgerEntryRepository;
+
+    private Member savedMember;
+    private Wallet savedWallet;
+    private Merchant savedMerchant;
+
+    @BeforeEach
+    void init() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        int randomNumber = ThreadLocalRandom.current().nextInt(10_000_000, 100_000_000);
+
+        savedMember = memberRepository.save(
+                Member.create(
+                        "payment-" + suffix + "@test.com",
+                        "payment-" + suffix,
+                        "+8210" + randomNumber
+                )
+        );
+        savedWallet = walletRepository.save(Wallet.create(savedMember, "paymentWallet", "BASC-V1"));
+        savedMerchant = merchantRepository.save(
+                Merchant.create("payment-store-" + suffix, "https://merchant.test/callback")
+        );
+
+        WalletBalance balance = walletBalanceRepository
+                .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)
+                .orElseThrow();
+        balance.increase(com.lemonpay.common.domain.Money.won(50_000));
+        walletBalanceRepository.save(balance);
+    }
+
+    @AfterEach
+    void clean() {
+        UserContextHolder.clear();
+    }
+
+
+    @Test
+    @DisplayName("동일 txNo 결제를 동시에 승인하면 1건만 성공하고 잔액과 원장은 1회만 반영된다.")
+    void approvePaymentConcurrently_thenOnlyOneApprovalIsApplied() throws InterruptedException {
+        // given
+        UserContextHolder.set(new UserContext(savedMember.getId()));
+        PaymentResult pendingPayment = paymentUseCase.createPendingPayment(new PaymentCommand.Create(
+                savedWallet.getId(),
+                savedMerchant.getId(),
+                Currency.KRW,
+                BigDecimal.valueOf(10_000),
+                Currency.KRW,
+                BigDecimal.valueOf(10_000),
+                BigDecimal.ONE,
+                "order-" + UUID.randomUUID(),
+                "idempotency-" + UUID.randomUUID()
+        ));
+        UserContextHolder.clear();
+
+        int tryCount = 2;
+        BigDecimal beforeAmount = walletBalanceRepository
+                .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)
+                .orElseThrow()
+                .getBalance();
+
+        ExecutorService executor = Executors.newFixedThreadPool(tryCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(tryCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+        for (int i = 0; i < tryCount; i++) {
+            executor.submit(() -> {
+                try {
+                    UserContextHolder.set(new UserContext(savedMember.getId()));
+                    startLatch.await();
+
+                    paymentUseCase.approvePayment(new PaymentCommand.Approve(pendingPayment.txNo()));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    failures.add(e);
+                } finally {
+                    UserContextHolder.clear();
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // when
+        startLatch.countDown();
+        boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdownNow();
+
+        // then
+        assertThat(completed).isTrue();
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(tryCount - 1);
+        assertThat(failures).isNotEmpty();
+        assertThat(failures).anySatisfy(this::assertExpectedConcurrencyException);
+
+        PaymentTransaction tx = paymentTransactionRepository.findByTxNo(pendingPayment.txNo()).orElseThrow();
+        assertThat(tx.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+
+        WalletBalance afterBalance = walletBalanceRepository
+                .findByWalletIdAndCurrency(savedWallet.getId(), Currency.KRW)
+                .orElseThrow();
+        assertThat(afterBalance.getBalance()).isEqualByComparingTo(beforeAmount.subtract(BigDecimal.valueOf(10_000)));
+
+        Page<LedgerEntry> paymentLedgers =
+                ledgerEntryRepository.findByWalletIdAndCurrencyAndEntryTypeOrderByIdDesc(
+                        savedWallet.getId(),
+                        Currency.KRW,
+                        EntryType.PAYMENT,
+                        PageRequest.of(0, 10)
+                );
+        assertThat(paymentLedgers.getContent()).hasSize(1);
+        assertThat(paymentLedgers.getContent().get(0).getAmount()).isEqualByComparingTo("10000");
+    }
+
+    private void assertExpectedConcurrencyException(Throwable failure) {
+        assertThat(failure)
+                .satisfiesAnyOf(
+                        e -> assertThat(e).isInstanceOf(ObjectOptimisticLockingFailureException.class),
+                        e -> assertThat(e).isInstanceOf(OptimisticLockingFailureException.class),
+                        e -> assertThat(e).isInstanceOf(CoreException.class)
+                                .extracting("errorType")
+                                .isEqualTo(ErrorType.INVALID_STATE_TRANSITION)
+
+                );
+    }
+}

--- a/src/test/java/com/lemonpay/payment/application/PaymentUseCaseIntegrationTest.java
+++ b/src/test/java/com/lemonpay/payment/application/PaymentUseCaseIntegrationTest.java
@@ -1,0 +1,199 @@
+package com.lemonpay.payment.application;
+
+import com.lemonpay.common.auth.UserContext;
+import com.lemonpay.common.auth.UserContextHolder;
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.member.domain.Member;
+import com.lemonpay.member.domain.MemberRepository;
+import com.lemonpay.merchant.domain.Merchant;
+import com.lemonpay.merchant.domain.MerchantRepository;
+import com.lemonpay.payment.domain.PaymentStatus;
+import com.lemonpay.payment.domain.PaymentTransaction;
+import com.lemonpay.payment.domain.PaymentTransactionRepository;
+import com.lemonpay.wallet.domain.Wallet;
+import com.lemonpay.wallet.domain.WalletRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+class PaymentUseCaseIntegrationTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private WalletRepository walletRepository;
+    @Autowired
+    private MerchantRepository merchantRepository;
+
+    @Autowired
+    private PaymentUseCase paymentUseCase;
+    @Autowired
+    private PaymentTransactionRepository paymentTransactionRepository;
+
+    private Member member;
+    private Wallet wallet;
+    private Merchant merchant;
+    private String today;
+
+    @BeforeEach
+    void setUp() {
+        member = saveMember();
+        wallet = saveWallet(member);
+        merchant = saveMerchant();
+        today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        log.info("Outer @BeforeEach, save data");
+    }
+
+    @AfterEach
+    void tearDown() {
+        UserContextHolder.clear();
+        log.info("Outer @AfterEach, tearDown");
+    }
+
+    private Member saveMember() {
+        String email = "lemonpay@gmail.com";
+        String name = "LemonPay";
+        String phone = "+821012341234";
+        Member member = Member.create(email, name, phone);
+        return memberRepository.save(member);
+    }
+
+    private Wallet saveWallet(Member member) {
+        String walletName = "WalletTest";
+        String productCode = "BASC-V1";
+        Wallet wallet = Wallet.create(member, walletName, productCode);
+        return walletRepository.save(wallet);
+    }
+
+    private Merchant saveMerchant() {
+        String name = "MerchantTest";
+        String callbackUrl = "https://www.merchant.com/exmaple/callback";
+        Merchant merchant = Merchant.create(name, callbackUrl);
+        return merchantRepository.save(merchant);
+    }
+
+    @Nested
+    @DisplayName("결제 요청 통합 테스트")
+    class PaymentCreation {
+        // 결제 요청 테스트 정상
+        @Test
+        @DisplayName("결제 요청 시 요청 상태의 결제 내역이 정상적으로 생성된다")
+        void createPayment_thenSuccess() {
+            // given
+            UserContextHolder.set(new UserContext(member.getId()));
+            var command = createKrwPaymentCommand();
+
+            // when
+            PaymentResult result = paymentUseCase.createPendingPayment(command);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.txNo()).isNotBlank();
+            assertThat(result.status()).isEqualTo(PaymentStatus.PENDING.name());
+            assertThat(result.txNo()).startsWith(today);
+            assertThat(result.txNo()).hasSize(18);
+
+            PaymentTransaction tx = paymentTransactionRepository.findByTxNo(result.txNo()).orElseThrow();
+            assertThat(tx.getStatus()).isEqualTo(PaymentStatus.PENDING);
+            assertThat(tx.getWalletId()).isEqualTo(wallet.getId());
+            assertThat(tx.getMerchantId()).isEqualTo(merchant.getId());
+            assertThat(tx.getAmount()).isEqualByComparingTo(command.amount());
+            assertThat(tx.getCurrency()).isEqualTo(command.currency());
+            assertThat(tx.getSettlementAmount()).isEqualByComparingTo(command.settlementAmount());
+            assertThat(tx.getSettlementCurrency()).isEqualTo(command.settlementCurrency());
+            assertThat(tx.getExchangeRate()).isEqualTo(command.exchangeRate());
+            assertThat(tx.getOrderId()).isEqualTo(command.orderId());
+
+        }
+
+        @Test
+        @DisplayName("결제 요청시 지갑 소유주가 다르면 예외가 발생한다.")
+        void createPayment_throwsValidationException() {
+            // given
+            UUID otherUserId = UUID.randomUUID();
+            UserContextHolder.set(new UserContext(otherUserId));
+            var command = createKrwPaymentCommand();
+            // when & then
+            assertThatThrownBy(() -> paymentUseCase.createPendingPayment(command))
+                    .isInstanceOf(CoreException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("결제 요청 시 가맹점이 ACTIVE 상태가 아닌, SUSPENDID 등의 상태이면 예외가 발생한다.")
+        void createPayment_throwsMerchantStateException() {
+            // given
+            UserContextHolder.set(new UserContext(member.getId()));
+            merchant.close();
+            var command = createKrwPaymentCommand();
+
+            // when & then
+            assertThatThrownBy(() -> paymentUseCase.createPendingPayment(command))
+                    .isInstanceOf(CoreException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.INVALID_REQUEST);
+        }
+
+        private PaymentCommand.Create createKrwPaymentCommand() {
+            Currency purchasedCurrency = Currency.KRW;
+            Currency settlementCurrency = Currency.KRW;
+            Money purchaseAmount = Money.of(1000, purchasedCurrency);
+            Money settlementAmount = Money.of(1000, settlementCurrency);
+            BigDecimal exchangeRate = BigDecimal.ONE;
+            String orderId = today + "ORDER" + UUID.randomUUID();
+            String idempotencyKey = today + UUID.randomUUID();
+
+            return new PaymentCommand.Create(
+                    wallet.getId(),
+                    merchant.getId(),
+                    purchaseAmount.currency(),
+                    purchaseAmount.amount(),
+                    settlementAmount.currency(),
+                    settlementAmount.amount(),
+                    exchangeRate,
+                    orderId,
+                    idempotencyKey
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 승인 통합 테스트")
+    class PaymentApprove {
+        // 결제 승인 테스트 정상
+
+        // 결제 승인 테스트 - 결제생성건이 없을때
+        // 결제 승인 테스트 - 이미 결제 처리가 되었을때
+        // 결제 승인 테스트 예외) 지갑 소유주 다를 때
+        // 결제 승인 테스트 - 가맹점이 정지 되었을때
+    }
+
+    @Nested
+    @DisplayName("결제 취소 통합 테스트")
+    class PaymentCancel {
+
+    }
+
+    @Nested
+    @DisplayName("결제 조회 통합 테스트")
+    class PaymentView {
+
+    }
+}

--- a/src/test/java/com/lemonpay/payment/application/PaymentUseCaseIntegrationTest.java
+++ b/src/test/java/com/lemonpay/payment/application/PaymentUseCaseIntegrationTest.java
@@ -6,6 +6,10 @@ import com.lemonpay.common.domain.Currency;
 import com.lemonpay.common.domain.Money;
 import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.ledger.domain.EntryType;
+import com.lemonpay.ledger.domain.LedgerEntry;
+import com.lemonpay.ledger.domain.LedgerEntryRepository;
+import com.lemonpay.ledger.infrastructure.LedgerEntryJpaRepository;
 import com.lemonpay.member.domain.Member;
 import com.lemonpay.member.domain.MemberRepository;
 import com.lemonpay.merchant.domain.Merchant;
@@ -13,12 +17,17 @@ import com.lemonpay.merchant.domain.MerchantRepository;
 import com.lemonpay.payment.domain.PaymentStatus;
 import com.lemonpay.payment.domain.PaymentTransaction;
 import com.lemonpay.payment.domain.PaymentTransactionRepository;
+import com.lemonpay.wallet.application.ChargeUseCase;
 import com.lemonpay.wallet.domain.Wallet;
+import com.lemonpay.wallet.domain.WalletBalance;
+import com.lemonpay.wallet.domain.WalletBalanceService;
 import com.lemonpay.wallet.domain.WalletRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -39,17 +48,26 @@ class PaymentUseCaseIntegrationTest {
     @Autowired
     private WalletRepository walletRepository;
     @Autowired
+    private WalletBalanceService walletBalanceService;
+    @Autowired
     private MerchantRepository merchantRepository;
 
     @Autowired
     private PaymentUseCase paymentUseCase;
     @Autowired
     private PaymentTransactionRepository paymentTransactionRepository;
+    @Autowired
+    private ChargeUseCase chargeUseCase;
+
+    @Autowired
+    private LedgerEntryRepository ledgerEntryRepository;
 
     private Member member;
     private Wallet wallet;
     private Merchant merchant;
     private String today;
+    @Autowired
+    private LedgerEntryJpaRepository ledgerEntryJpaRepository;
 
     @BeforeEach
     void setUp() {
@@ -97,7 +115,7 @@ class PaymentUseCaseIntegrationTest {
         void createPayment_thenSuccess() {
             // given
             UserContextHolder.set(new UserContext(member.getId()));
-            var command = createKrwPaymentCommand();
+            var command = createDefaultKrwPaymentCommand();
 
             // when
             PaymentResult result = paymentUseCase.createPendingPayment(command);
@@ -128,7 +146,7 @@ class PaymentUseCaseIntegrationTest {
             // given
             UUID otherUserId = UUID.randomUUID();
             UserContextHolder.set(new UserContext(otherUserId));
-            var command = createKrwPaymentCommand();
+            var command = createDefaultKrwPaymentCommand();
             // when & then
             assertThatThrownBy(() -> paymentUseCase.createPendingPayment(command))
                     .isInstanceOf(CoreException.class)
@@ -142,7 +160,7 @@ class PaymentUseCaseIntegrationTest {
             // given
             UserContextHolder.set(new UserContext(member.getId()));
             merchant.close();
-            var command = createKrwPaymentCommand();
+            var command = createDefaultKrwPaymentCommand();
 
             // when & then
             assertThatThrownBy(() -> paymentUseCase.createPendingPayment(command))
@@ -150,35 +168,71 @@ class PaymentUseCaseIntegrationTest {
                     .extracting("errorType")
                     .isEqualTo(ErrorType.INVALID_REQUEST);
         }
-
-        private PaymentCommand.Create createKrwPaymentCommand() {
-            Currency purchasedCurrency = Currency.KRW;
-            Currency settlementCurrency = Currency.KRW;
-            Money purchaseAmount = Money.of(1000, purchasedCurrency);
-            Money settlementAmount = Money.of(1000, settlementCurrency);
-            BigDecimal exchangeRate = BigDecimal.ONE;
-            String orderId = today + "ORDER" + UUID.randomUUID();
-            String idempotencyKey = today + UUID.randomUUID();
-
-            return new PaymentCommand.Create(
-                    wallet.getId(),
-                    merchant.getId(),
-                    purchaseAmount.currency(),
-                    purchaseAmount.amount(),
-                    settlementAmount.currency(),
-                    settlementAmount.amount(),
-                    exchangeRate,
-                    orderId,
-                    idempotencyKey
-            );
-        }
     }
 
     @Nested
     @DisplayName("결제 승인 통합 테스트")
     class PaymentApprove {
-        // 결제 승인 테스트 정상
 
+        private PaymentResult pendingPayment;
+
+        @BeforeEach
+        void setUp() {
+            UserContextHolder.set(new UserContext(member.getId()));
+            pendingPayment = paymentUseCase.createPendingPayment(createDefaultKrwPaymentCommand());
+        }
+
+
+        // 결제 승인 테스트 정상
+        @Test
+        @DisplayName("PENDING 결제를 승인하면 COMPLETED 상태가 되고 잔액 차감과 원장 기록이 생성된다.")
+        void approvePayment_thenSuccess() {
+            // given
+            Currency givenCurrency = Currency.valueOf(pendingPayment.currency());
+            Money chargeMoney = Money.of(pendingPayment.amount(), givenCurrency);
+            chargeUseCase.charge(pendingPayment.walletId(), chargeMoney);
+            PaymentCommand.Approve command = new PaymentCommand.Approve(pendingPayment.txNo());
+            Money beforeBalance = walletBalanceService.getWalletBalance(pendingPayment.walletId(), givenCurrency)
+                    .toMoney();
+
+            // when
+            PaymentResult result = paymentUseCase.approvePayment(command);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.txNo()).isNotBlank();
+            assertThat(result.txNo()).isNotBlank();
+            assertThat(result.status()).isEqualTo(PaymentStatus.COMPLETED.name());
+            assertThat(result.txNo()).startsWith(today);
+            assertThat(result.txNo()).hasSize(18);
+            // Money afterBalance = Money.of(result.amount(), givenCurrency);
+            // assertThat(afterBalance).isEqualTo(beforeBalance.subtract(chargeMoney));
+
+            PaymentTransaction tx = paymentTransactionRepository.findByTxNo(result.txNo()).orElseThrow();
+            assertThat(tx.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+            assertThat(tx.getWalletId()).isEqualTo(wallet.getId());
+            assertThat(tx.getMerchantId()).isEqualTo(merchant.getId());
+
+            assertThat(tx.getAmount()).isEqualByComparingTo(pendingPayment.amount());
+            assertThat(tx.getCurrency()).isEqualTo(Currency.valueOf(pendingPayment.currency()));
+            assertThat(tx.getSettlementAmount()).isEqualByComparingTo(pendingPayment.settlementAmount());
+            assertThat(tx.getSettlementCurrency()).isEqualTo(Currency.valueOf(pendingPayment.settlementCurrency()));
+            assertThat(tx.getExchangeRate()).isEqualTo(pendingPayment.exchangeRate());
+
+            Money afterBalance = walletBalanceService.getWalletBalance(pendingPayment.walletId(), givenCurrency)
+                    .toMoney();
+            assertThat(afterBalance).isEqualTo(beforeBalance.subtract(chargeMoney));
+
+            Page<LedgerEntry> paymentLedgers =
+                    ledgerEntryRepository.findByWalletIdAndCurrencyAndEntryTypeOrderByIdDesc(
+                            result.walletId(),
+                            givenCurrency,
+                            EntryType.PAYMENT,
+                            PageRequest.of(0, 10)
+                    );
+            assertThat(paymentLedgers.getContent()).hasSize(1);
+            assertThat(paymentLedgers.getContent().get(0).getAmount()).isEqualByComparingTo(chargeMoney.amount());
+        }
         // 결제 승인 테스트 - 결제생성건이 없을때
         // 결제 승인 테스트 - 이미 결제 처리가 되었을때
         // 결제 승인 테스트 예외) 지갑 소유주 다를 때
@@ -195,5 +249,28 @@ class PaymentUseCaseIntegrationTest {
     @DisplayName("결제 조회 통합 테스트")
     class PaymentView {
 
+    }
+
+
+    private PaymentCommand.Create createDefaultKrwPaymentCommand() {
+        Currency purchasedCurrency = Currency.KRW;
+        Currency settlementCurrency = Currency.KRW;
+        Money purchaseAmount = Money.of(1000, purchasedCurrency);
+        Money settlementAmount = Money.of(1000, settlementCurrency);
+        BigDecimal exchangeRate = BigDecimal.ONE;
+        String orderId = today + "ORDER" + UUID.randomUUID();
+        String idempotencyKey = today + UUID.randomUUID();
+
+        return new PaymentCommand.Create(
+                wallet.getId(),
+                merchant.getId(),
+                purchaseAmount.currency(),
+                purchaseAmount.amount(),
+                settlementAmount.currency(),
+                settlementAmount.amount(),
+                exchangeRate,
+                orderId,
+                idempotencyKey
+        );
     }
 }

--- a/src/test/java/com/lemonpay/payment/domain/PaymentStatusTest.java
+++ b/src/test/java/com/lemonpay/payment/domain/PaymentStatusTest.java
@@ -1,0 +1,85 @@
+package com.lemonpay.payment.domain;
+
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * 상태 전이 규칙을 검증합니다.
+ */
+class PaymentStatusTest {
+
+    @Test
+    @DisplayName("PENDING 상태에서 COMPLETED, FAILED, CANCELLED 로 상태 전이가 가능하다.")
+    void transitionFromPending_thenSuccess() {
+        // given
+        PaymentStatus status = PaymentStatus.PENDING;
+
+        // when & then
+        assertAll(
+                () -> assertTrue(status.canTransitionTo(PaymentStatus.COMPLETED)),
+                () -> assertTrue(status.canTransitionTo(PaymentStatus.FAILED)),
+                () -> assertTrue(status.canTransitionTo(PaymentStatus.CANCELLED))
+        );
+
+    }
+
+    @Test
+    @DisplayName("COMPLETED, FAILED, CANCELLED 인 경우 다른 상태로 전이가 불가능하다.")
+    void transitionFromTerminal_thenUnable() {
+        // given
+        PaymentStatus completed = PaymentStatus.COMPLETED;
+        PaymentStatus failed = PaymentStatus.FAILED;
+        PaymentStatus cancelled = PaymentStatus.CANCELLED;
+
+        // when & then
+        assertAll(
+                () -> assertTrue(completed.allowedTransitions().isEmpty()),
+                () -> assertTrue(failed.allowedTransitions().isEmpty()),
+                () -> assertTrue(cancelled.allowedTransitions().isEmpty())
+        );
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("invalidTransitions")
+    @DisplayName("불가능한 전이는 INVALID_STATE_TRANSITION 에러 타입으로 CoreException이 발생한다.")
+    void invalidTransition_throwsException(PaymentStatus current, PaymentStatus next) {
+        // when & then
+        assertThatThrownBy(() -> current.validateTransition(next))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.INVALID_STATE_TRANSITION);
+    }
+
+    static Stream<Arguments> invalidTransitions() {
+        return Stream.of(
+                Arguments.of(PaymentStatus.COMPLETED, PaymentStatus.COMPLETED),
+                Arguments.of(PaymentStatus.COMPLETED, PaymentStatus.FAILED),
+                Arguments.of(PaymentStatus.COMPLETED, PaymentStatus.CANCELLED),
+                Arguments.of(PaymentStatus.COMPLETED, PaymentStatus.PENDING),
+
+                Arguments.of(PaymentStatus.FAILED, PaymentStatus.COMPLETED),
+                Arguments.of(PaymentStatus.FAILED, PaymentStatus.FAILED),
+                Arguments.of(PaymentStatus.FAILED, PaymentStatus.CANCELLED),
+                Arguments.of(PaymentStatus.FAILED, PaymentStatus.PENDING),
+
+                Arguments.of(PaymentStatus.CANCELLED, PaymentStatus.COMPLETED),
+                Arguments.of(PaymentStatus.CANCELLED, PaymentStatus.FAILED),
+                Arguments.of(PaymentStatus.CANCELLED, PaymentStatus.CANCELLED),
+                Arguments.of(PaymentStatus.CANCELLED, PaymentStatus.PENDING)
+        );
+    }
+
+
+}

--- a/src/test/java/com/lemonpay/payment/domain/PaymentTransactionServiceTest.java
+++ b/src/test/java/com/lemonpay/payment/domain/PaymentTransactionServiceTest.java
@@ -1,0 +1,205 @@
+package com.lemonpay.payment.domain;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentTransactionServiceTest {
+
+    private static final String TX_NO = "202605180000000001";
+    private static final String IDEMPOTENCY_KEY = "idempotency-key";
+    private static final String ORDER_ID = "order-id";
+
+    @InjectMocks
+    private PaymentTransactionService paymentTransactionService;
+
+    @Mock
+    private PaymentTransactionRepository paymentTransactionRepository;
+
+    @Nested
+    @DisplayName("결제 요청 생성")
+    class CreatePending {
+
+        @Test
+        @DisplayName("신규 결제 요청이면 PENDING 거래를 저장한다.")
+        void createPending_withNewRequest_savesPendingTransaction() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            UUID merchantId = UUID.randomUUID();
+            Money amount = Money.won(10_000);
+
+            given(paymentTransactionRepository.findByMerchantIdAndIdempotencyKey(merchantId, IDEMPOTENCY_KEY))
+                    .willReturn(Optional.empty());
+            given(paymentTransactionRepository.existsByTxNo(TX_NO)).willReturn(false);
+            given(paymentTransactionRepository.save(any(PaymentTransaction.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            PaymentTransaction result = paymentTransactionService.createPending(
+                    TX_NO,
+                    walletId,
+                    merchantId,
+                    amount,
+                    amount,
+                    BigDecimal.ONE,
+                    IDEMPOTENCY_KEY,
+                    ORDER_ID
+            );
+
+            // then
+            assertThat(result.getTxNo()).isEqualTo(TX_NO);
+            assertThat(result.getWalletId()).isEqualTo(walletId);
+            assertThat(result.getMerchantId()).isEqualTo(merchantId);
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.PENDING);
+            then(paymentTransactionRepository).should().save(any(PaymentTransaction.class));
+        }
+
+        @Test
+        @DisplayName("같은 가맹점의 동일 idempotencyKey 요청이면 기존 거래를 반환한다.")
+        void createPending_withSameIdempotencyKey_returnsExistingTransaction() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            UUID merchantId = UUID.randomUUID();
+            PaymentTransaction existing = createPendingTransaction(walletId, merchantId);
+
+            given(paymentTransactionRepository.findByMerchantIdAndIdempotencyKey(merchantId, IDEMPOTENCY_KEY))
+                    .willReturn(Optional.of(existing));
+
+            // when
+            PaymentTransaction result = paymentTransactionService.createPending(
+                    "202605180000000002",
+                    walletId,
+                    merchantId,
+                    Money.won(10_000),
+                    Money.won(10_000),
+                    BigDecimal.ONE,
+                    IDEMPOTENCY_KEY,
+                    ORDER_ID
+            );
+
+            // then
+            assertThat(result).isSameAs(existing);
+            then(paymentTransactionRepository).should(never()).save(any(PaymentTransaction.class));
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 txNo이면 예외가 발생한다.")
+        void createPending_withDuplicatedTxNo_throwsException() {
+            // given
+            UUID walletId = UUID.randomUUID();
+            UUID merchantId = UUID.randomUUID();
+
+            given(paymentTransactionRepository.findByMerchantIdAndIdempotencyKey(merchantId, IDEMPOTENCY_KEY))
+                    .willReturn(Optional.empty());
+            given(paymentTransactionRepository.existsByTxNo(TX_NO)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> paymentTransactionService.createPending(
+                    TX_NO,
+                    walletId,
+                    merchantId,
+                    Money.won(10_000),
+                    Money.won(10_000),
+                    BigDecimal.ONE,
+                    IDEMPOTENCY_KEY,
+                    ORDER_ID
+            ))
+                    .isInstanceOf(CoreException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.INVALID_REQUEST);
+
+            then(paymentTransactionRepository).should(never()).save(any(PaymentTransaction.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 상태 변경")
+    class Transition {
+
+        @Test
+        @DisplayName("PENDING 거래를 COMPLETED로 변경한다.")
+        void complete_withPendingTransaction_changesStatusToCompleted() {
+            // given
+            PaymentTransaction paymentTransaction = createPendingTransaction(UUID.randomUUID(), UUID.randomUUID());
+
+            given(paymentTransactionRepository.findByTxNo(TX_NO)).willReturn(Optional.of(paymentTransaction));
+            given(paymentTransactionRepository.save(paymentTransaction)).willReturn(paymentTransaction);
+
+            // when
+            PaymentTransaction result = paymentTransactionService.complete(TX_NO);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+            assertThat(result.getCompletedAt()).isNotNull();
+            then(paymentTransactionRepository).should().save(paymentTransaction);
+        }
+
+        @Test
+        @DisplayName("PENDING 거래를 CANCELLED로 변경한다.")
+        void cancel_withPendingTransaction_changesStatusToCancelled() {
+            // given
+            PaymentTransaction paymentTransaction = createPendingTransaction(UUID.randomUUID(), UUID.randomUUID());
+
+            given(paymentTransactionRepository.findByTxNo(TX_NO)).willReturn(Optional.of(paymentTransaction));
+            given(paymentTransactionRepository.save(paymentTransaction)).willReturn(paymentTransaction);
+
+            // when
+            PaymentTransaction result = paymentTransactionService.cancel(TX_NO);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+            assertThat(result.getCancelledAt()).isNotNull();
+            then(paymentTransactionRepository).should().save(paymentTransaction);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 거래번호이면 예외가 발생한다.")
+        void complete_withUnknownTxNo_throwsException() {
+            // given
+            given(paymentTransactionRepository.findByTxNo(TX_NO)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> paymentTransactionService.complete(TX_NO))
+                    .isInstanceOf(CoreException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.NOT_FOUND);
+
+            then(paymentTransactionRepository).should(never()).save(any(PaymentTransaction.class));
+        }
+    }
+
+    private PaymentTransaction createPendingTransaction(UUID walletId, UUID merchantId) {
+        return PaymentTransaction.create(
+                TX_NO,
+                walletId,
+                merchantId,
+                BigDecimal.valueOf(10_000),
+                Currency.KRW,
+                BigDecimal.valueOf(10_000),
+                Currency.KRW,
+                BigDecimal.ONE,
+                IDEMPOTENCY_KEY,
+                ORDER_ID
+        );
+    }
+}

--- a/src/test/java/com/lemonpay/payment/domain/PaymentTransactionTest.java
+++ b/src/test/java/com/lemonpay/payment/domain/PaymentTransactionTest.java
@@ -1,0 +1,172 @@
+package com.lemonpay.payment.domain;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentTransactionTest {
+
+    @Nested
+    @DisplayName("생성 테스트")
+    class Creation {
+
+        @Test
+        @DisplayName("create() 시 PENDING 상태로 생성된다.")
+        void createPaymentTransaction_success() {
+            //given & when
+            PaymentTransaction paymentTransaction = createPendingTransactionByKrw();
+
+            // then
+            assertNotNull(paymentTransaction);
+            assertEquals(PaymentStatus.PENDING, paymentTransaction.getStatus());
+        }
+
+        @Test
+        @DisplayName("create() 시 txNo, walletId, merchantId, amount, currency, idempotencyKey가 저장된다.")
+        void createPaymentTransactionCheckParams_success() {
+            // given & when
+            PaymentTransaction paymentTransaction = createPendingTransactionByKrw();
+
+            // then
+            assertNotNull(paymentTransaction);
+            assertEquals("202605090000000001", paymentTransaction.getTxNo());
+            assertNotNull(paymentTransaction.getWalletId());
+            assertNotNull(paymentTransaction.getMerchantId());
+            assertEquals(PaymentStatus.PENDING, paymentTransaction.getStatus());
+            assertThat(paymentTransaction.getAmount()).isEqualByComparingTo("10000");
+            assertEquals(Currency.KRW, paymentTransaction.getCurrency());
+            assertThat(paymentTransaction.getSettlementAmount()).isEqualByComparingTo("10000");
+            assertEquals(Currency.KRW, paymentTransaction.getSettlementCurrency());
+            assertThat(paymentTransaction.getExchangeRate()).isEqualByComparingTo("0");
+            assertEquals("idempotency_key", paymentTransaction.getIdempotencyKey());
+        }
+
+        @Test
+        @DisplayName("create() 시 completedAt, cancelledAt은 null이다.")
+        void createPaymentTransactionCheckTimeStamp_success() {
+            // given & when
+            PaymentTransaction paymentTransaction = createPendingTransactionByKrw();
+
+            // then
+            assertNull(paymentTransaction.getCompletedAt());
+            assertNull(paymentTransaction.getCancelledAt());
+        }
+
+
+    }
+
+    @Nested
+    @DisplayName("상태 전이 메소드 테스트")
+    class Transition {
+        PaymentTransaction paymentTransaction;
+
+        @BeforeEach
+        void setUp() {
+            paymentTransaction = createPendingTransactionByKrw();
+        }
+
+        @Test
+        @DisplayName("complete() 호출 시 PENDING -> COMPLETED 전이되고, completedAt이 기록된다.")
+        void completePaymentTransaction_success() {
+            // given & when
+            paymentTransaction.complete();
+
+            // then
+            assertEquals(PaymentStatus.COMPLETED, paymentTransaction.getStatus());
+            assertNotNull(paymentTransaction.getCompletedAt());
+        }
+
+
+        @Test
+        @DisplayName("cancel() 호출 시 PENDING -> CANCELLED 전이되고, cancelledAt이 기록된다.")
+        void cancelPaymentTransaction_success() {
+            // given & when
+            paymentTransaction.cancel();
+
+            // then
+            assertEquals(PaymentStatus.CANCELLED, paymentTransaction.getStatus());
+            assertNotNull(paymentTransaction.getCancelledAt());
+        }
+
+        @Test
+        @DisplayName("failed() 호출 시 PENDING -> FAILED 전이된다.")
+        void failedTransition_success() {
+            // given & when
+            paymentTransaction.failed();
+
+            // then
+            assertEquals(PaymentStatus.FAILED, paymentTransaction.getStatus());
+        }
+
+        /**
+         * PaymentStatusTest에서 모든 전이 케이스를 검증하므로, PaymentTransactionTest에서는 대표 케이스만 검증한다.
+         */
+        @Test
+        @DisplayName("COMPLETED 상태에서는 cancel() 불가하다")
+        void invalidTransitionFromCompleted_throwsException() {
+            // given
+            paymentTransaction.complete();
+
+            // when & then
+            assertThatThrownBy(() -> paymentTransaction.cancel())
+                    .isInstanceOf(CoreException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.INVALID_STATE_TRANSITION);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태에서는 complete() 불가하다")
+        void invalidTransitionFromFailed_throwsException() {
+            // given
+            paymentTransaction.failed();
+
+            // when & then
+            assertThatThrownBy(() -> paymentTransaction.complete())
+                    .isInstanceOf(CoreException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.INVALID_STATE_TRANSITION);
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태에서는 complete() 불가하다")
+        void invalidTransitionFromCancelled_throwsException() {
+            // given
+            paymentTransaction.cancel();
+
+            // when & then
+            assertThatThrownBy(() -> paymentTransaction.complete())
+                    .isInstanceOf(CoreException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.INVALID_STATE_TRANSITION);
+        }
+
+
+
+
+    }
+
+    private PaymentTransaction createPendingTransactionByKrw() {
+        return PaymentTransaction.create(
+                "202605090000000001",
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                BigDecimal.valueOf(10_000),
+                Currency.KRW,
+                BigDecimal.valueOf(10_000),
+                Currency.KRW,
+                BigDecimal.valueOf(0),
+                "idempotency_key"
+        );
+    }
+}

--- a/src/test/java/com/lemonpay/payment/domain/PaymentTransactionTest.java
+++ b/src/test/java/com/lemonpay/payment/domain/PaymentTransactionTest.java
@@ -166,7 +166,8 @@ class PaymentTransactionTest {
                 BigDecimal.valueOf(10_000),
                 Currency.KRW,
                 BigDecimal.valueOf(0),
-                "idempotency_key"
+                "idempotency_key",
+                "ORDER-20260518-TEST-001"
         );
     }
 }


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->

결제 유즈케이스 구현 전 API 스펙, 시퀀스다이어그램, 도메인 모델/상태머신 을 구현하였습니다.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
- 결제 MVP 유즈케이스 시퀀스 다이어그램 추가
- PaymentTransaction 엔티티 추가
- PaymentStatus 상태 전이 규칙 추가
- yyyyMMdd + 10자리 순번 형식의 txNo 채번 로직 추가
- PaymentStatus / PaymentTransaction 도메인 테스트 추가
- 결제 요청 생성 유스케이스 구현
- 결제 승인 유스케이스 구현
- PAYMENT 원장 기록 연동
- 잔액 부족/중복 승인 통합 테스트 추가

## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->
- PaymentTransaction은 Wallet/Merchant를 JPA 연관관계로 직접 참조하지 않고 ID로 참조합니다.
- txNo는 외부 노출용 거래번호로 내부 PK와 분리했습니다.
- MVP에서는 날짜별 순번 보장을 위해 sequence row에 pessimistic write lock을 적용했습니다.
- 결제 상태는 PENDING, COMPLETED, FAILED, CANCELLED로 제한했습니다.
- 유즈케이스 비즈니스 로직은 가독성 좋게 개선. 단 헬퍼 메소드는 최소화.

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- [x] 신규 테이블: payment_tx_no_sequence, payment_transactions
- [x] 인덱스 추가: 
  - `uk_payment_transactions_tx_no`
  - `uk_payment_transactions_merchant_idempotency`

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- [x] 신규 API 인터페이스 스펙 정의:
    - POST /api/v1/payments는 가맹점 결제 요청 생성 API
    - POST /api/v1/payments/{paymentId}/approve 실제 잔액 차감 및 승인 API
    - POST /api/v1/apyments/{paymentId}/cancel 결제 취소 API
    - GET /api/v1/payments/{paymentId} 는 결제 내역 조회 
## 테스트
- [x] PaymentStatus 상태 전이 규칙 단위 테스트 추가
- [x] PaymentTransaction 생성 및 상태 전이 단위 테스트 추가
- [x] PaymentTxNoGeneratorTest 생성 테스트 추가
- [x] PaymentUseCaseIntegrationTest 통합테스트 추가
- [x] PaymentUseCaseConcurrencyTest 동시성 테스트 추가

## CI 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과

## 후속 작업

## 관련 이슈
<!-- Closes #이슈번호 -->
Closes: #22 
Refs: #44 