### PR TITLE
refactor(interfaces): 예외 응답 구조, 정상 응답 구조 표준화

### DIFF
--- a/src/main/java/com/lemonpay/common/interfaces/ApiResponse.java
+++ b/src/main/java/com/lemonpay/common/interfaces/ApiResponse.java
@@ -1,0 +1,17 @@
+package com.lemonpay.common.interfaces;
+
+import java.time.OffsetDateTime;
+
+public record ApiResponse<T>(MetaData meta, T data) {
+
+    public record MetaData(String timestamp) {
+        public static MetaData now() {
+            return new MetaData(OffsetDateTime.now().toString());
+        }
+    }
+
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(MetaData.now(), data);
+    }
+
+}

--- a/src/main/java/com/lemonpay/common/interfaces/ErrorResponse.java
+++ b/src/main/java/com/lemonpay/common/interfaces/ErrorResponse.java
@@ -1,16 +1,35 @@
 package com.lemonpay.common.interfaces;
 
 import com.lemonpay.common.exception.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * 추후 RFC 9457를 구현한 ProblemDetail로 변경을 고려할 수 있다.
+ *
+ * @param errorCode
+ * @param message JSON string containing a human-readable explanation specific to this occurrence of the problem.
+ * @param status JSON number indicating the HTTP status code.
+ * @param title JSON string containing a short, human-readable summary of the problem type.
+ * @param instance JSON string containing a URI reference that identifies the specific occurrence of the problem.
+ */
 public record ErrorResponse(
-        String code,
-        String message
+        String errorCode,
+        String message,
+        int status,
+        String title,
+        String instance
 ) {
-    public static ErrorResponse of(ErrorType errorType) {
-        return new ErrorResponse(errorType.name(), errorType.getMessage());
+    public static ErrorResponse of(ErrorType errorType, HttpServletRequest request) {
+        return of(errorType, errorType.getMessage(), request);
     }
 
-    public static ErrorResponse of(ErrorType errorType, String detail) {
-        return new ErrorResponse(errorType.name(), detail);
+    public static ErrorResponse of(ErrorType errorType, String message, HttpServletRequest request) {
+        return new ErrorResponse(
+                errorType.name(),
+                message,
+                errorType.getStatus().value(),
+                errorType.getStatus().getReasonPhrase(),
+                request.getRequestURI()
+        );
     }
 }

--- a/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
+++ b/src/main/java/com/lemonpay/common/interfaces/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.lemonpay.common.interfaces;
 
 import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.common.exception.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.ResponseEntity;
@@ -19,61 +20,67 @@ import java.util.stream.Collectors;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CoreException.class)
-    public ResponseEntity<ErrorResponse> handleCoreException(CoreException e) {
+    public ResponseEntity<ErrorResponse> handleCoreException(CoreException e, HttpServletRequest request) {
         log.warn("CoreException: {}", e.getMessage());
         ErrorType errorType = e.getErrorType();
         return ResponseEntity
                 .status(errorType.getStatus())
-                .body(ErrorResponse.of(errorType, e.getMessage()));
+                .body(ErrorResponse.of(errorType, e.getMessage(), request));
     }
 
     /** @Valid 검증 실패 */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e,
+                                                                   HttpServletRequest request) {
         String detail = e.getBindingResult().getFieldErrors().stream()
                 .map(FieldError::getDefaultMessage)
                 .collect(Collectors.joining(", "));
         log.warn("Validation failed: {}", detail);
         return ResponseEntity
                 .badRequest()
-                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail));
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail, request));
     }
 
     /** PathVariable/RequestParam 타입 불일치 (e.g. UUID 형식 오류) */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e,
+                                                                     HttpServletRequest request) {
         String detail = "'%s' 파라미터의 값이 올바르지 않습니다.".formatted(e.getName());
         log.warn("Type mismatch: {}", detail);
         return ResponseEntity
                 .badRequest()
-                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail));
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail, request));
     }
 
     /** JSON 파싱 오류 */
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponse> handleNotReadableException(HttpMessageNotReadableException e) {
+    public ResponseEntity<ErrorResponse> handleNotReadableException(HttpMessageNotReadableException e,
+                                                                    HttpServletRequest request) {
         log.warn("HttpMessageNotReadable: {}", e.getMessage());
+        String detail = "요청 본문을 읽을 수 없습니다.";
         return ResponseEntity
                 .badRequest()
-                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, "요청 본문을 읽을 수 없습니다."));
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail, request));
     }
 
     /** 예상하지 못한 예외 */
     @ExceptionHandler(Throwable.class)
-    public ResponseEntity<ErrorResponse> handleUnexpectedException(Throwable e) {
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(Throwable e, HttpServletRequest request) {
         log.error("Unexpected error", e);
+        String detail = "예상치 못한 예외가 발생했습니다.";
         return ResponseEntity
                 .internalServerError()
-                .body(ErrorResponse.of(ErrorType.INTERNAL_SERVER_ERROR));
+                .body(ErrorResponse.of(ErrorType.INTERNAL_SERVER_ERROR, detail, request));
     }
 
     /** 잘못된 sort 필드명이 넘어왔을 때 500 대신 400 반환 */
     @ExceptionHandler(PropertyReferenceException.class)
-    public ResponseEntity<ErrorResponse> handlePropertyReferenceException(PropertyReferenceException e) {
+    public ResponseEntity<ErrorResponse> handlePropertyReferenceException(PropertyReferenceException e,
+                                                                          HttpServletRequest request) {
         log.warn("Invalid sort field: {}", e.getPropertyName());
+        String detail = String.format("정렬 기준이 올바르지 않습니다 : %s", e.getPropertyName());
         return ResponseEntity
                 .badRequest()
-                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST,
-                        "정렬 기준이 올바르지 않습니다: " + e.getPropertyName()));
+                .body(ErrorResponse.of(ErrorType.INVALID_REQUEST, detail, request));
     }
 }


### PR DESCRIPTION
 ## 개요
  공통 API 응답 구조를 정리했습니다. 성공 응답은 `ApiResponse`로 감싸고, 예외 응답은 RFC 9457 형식에 가까운 필드를 포함하도록 확장했습니다.

  ## 변경 사항
  - 성공 응답을 위한 `ApiResponse<T>` 추가
  - `ErrorResponse`에 `status`, `title`, `instance` 등 RFC 9457 기반 필드 추가
  - `GlobalExceptionHandler`의 예외 응답 생성 방식 정리
  - Controller 응답을 표준 응답 구조로 변환

  ## 설계 결정
  - 성공 응답과 예외 응답은 분리했습니다.
    - 성공 응답은 `metadata`, `data` 구조로 통일했습니다.
    - 예외 응답은 프론트엔드에서 바로 다루기 쉽도록 기존 `errorCode`, `message`를 유지하면서 RFC 9457의 주요 필드를 추가했습니다.
  - Spring `ProblemDetail`을 직접 반환하는 방식도 검토했지만, 현재 프론트엔드 호환성과 응답 필드 제어를 우선해 `ErrorResponse`를 유지했습니다.
  - HTTP status는 `ResponseEntity.status(...)`로 유지하고, body의 `status`는 클라이언트가 읽는 보조 정보로 함께 제공합니다.

  ## API 변경
  - 신규 엔드포인트: 없음
  - [x] Request/Response 변경:
    - 성공 응답이 `ApiResponse<T>` 형태로 감싸집니다.
    - 예외 응답 필드가 `errorCode`, `message`, `status`, `title`, `instance` 형태로 확장됩니다.
  - [x] 하위 호환성:
    - 기존 Response body 구조가 변경되므로 프론트엔드 응답 파싱 코드 수정이 필요합니다.