### PR TITLE
refactor(interfaces): ApiResponse 표준 응답 적용

### DIFF
--- a/src/main/java/com/lemonpay/common/interfaces/ApiResponse.java
+++ b/src/main/java/com/lemonpay/common/interfaces/ApiResponse.java
@@ -2,16 +2,16 @@ package com.lemonpay.common.interfaces;
 
 import java.time.OffsetDateTime;
 
-public record ApiResponse<T>(MetaData meta, T data) {
+public record ApiResponse<T>(Metadata meta, T data) {
 
-    public record MetaData(String timestamp) {
-        public static MetaData now() {
-            return new MetaData(OffsetDateTime.now().toString());
+    public record Metadata(String timestamp) {
+        public static Metadata now() {
+            return new Metadata(OffsetDateTime.now().toString());
         }
     }
 
     public static <T> ApiResponse<T> of(T data) {
-        return new ApiResponse<>(MetaData.now(), data);
+        return new ApiResponse<>(Metadata.now(), data);
     }
 
 }

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1ApiSpec.java
@@ -1,5 +1,6 @@
 package com.lemonpay.payment.interfaces.api;
 
+import com.lemonpay.common.interfaces.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,7 +19,7 @@ public interface PaymentV1ApiSpec {
             summary = "가맹점 결제 요청 생성 API",
             description = "가맹점 클라이언트에서 레몬페이로 결제 요청 생성"
     )
-    ResponseEntity<PaymentDto.PaymentResponse> create(
+    ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> create(
             @Valid @RequestBody PaymentDto.CreationRequest request
     );
 
@@ -27,8 +28,8 @@ public interface PaymentV1ApiSpec {
             summary = "결제 승인 API",
             description = "레몬페이 잔액 차감 및 결제 승인을 처리"
     )
-    ResponseEntity<PaymentDto.PaymentResponse> approve(
-            @Parameter(description = "결제 ID", required = true)
+    ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> approve(
+            @Parameter(description = "결제 번호", required = true)
             @PathVariable("txNo") String txNo
     );
 
@@ -37,18 +38,18 @@ public interface PaymentV1ApiSpec {
             summary = "결제 취소 API",
             description = "레몬페이 결제 취소 처리"
     )
-    ResponseEntity<PaymentDto.PaymentResponse> cancel(
-            @Parameter(description = "결제 ID", required = true)
+    ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> cancel(
+            @Parameter(description = "결제 번호", required = true)
             @PathVariable("txNo") String txNo
     );
 
     @GetMapping("/{txNo}")
     @Operation(
             summary = "결제 내역 조회 API",
-            description = "결제 ID에 대한 세부 내역 정보 응답"
+            description = "결제 번호에 대한 세부 내역 정보 응답"
     )
-    ResponseEntity<PaymentDto.PaymentResponse> detail(
-            @Parameter(description = "결제 ID", required = true)
+    ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> detail(
+            @Parameter(description = "결제 번호", required = true)
             @PathVariable("txNo") String txNo
     );
 }

--- a/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1Controller.java
+++ b/src/main/java/com/lemonpay/payment/interfaces/api/PaymentV1Controller.java
@@ -1,5 +1,6 @@
 package com.lemonpay.payment.interfaces.api;
 
+import com.lemonpay.common.interfaces.ApiResponse;
 import com.lemonpay.payment.application.PaymentCommand;
 import com.lemonpay.payment.application.PaymentUseCase;
 import lombok.RequiredArgsConstructor;
@@ -17,29 +18,37 @@ public class PaymentV1Controller implements PaymentV1ApiSpec {
     private final PaymentUseCase paymentUseCase;
 
     @Override
-    public ResponseEntity<PaymentDto.PaymentResponse> create(PaymentDto.CreationRequest request) {
+    public ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> create(PaymentDto.CreationRequest request) {
         var result = paymentUseCase.createPendingPayment(request.toCommand());
-        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
+        return ResponseEntity.ok(
+                ApiResponse.of(PaymentDto.PaymentResponse.from(result))
+        );
     }
 
     @Override
-    public ResponseEntity<PaymentDto.PaymentResponse> approve(String txNo) {
+    public ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> approve(String txNo) {
         var command = new PaymentCommand.Approve(txNo);
         var result = paymentUseCase.approvePayment(command);
-        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
+        return ResponseEntity.ok(
+                ApiResponse.of(PaymentDto.PaymentResponse.from(result))
+        );
     }
 
     @Override
-    public ResponseEntity<PaymentDto.PaymentResponse> cancel(String txNo) {
+    public ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> cancel(String txNo) {
         var command = new PaymentCommand.Cancel(txNo);
         var result = paymentUseCase.cancelPayment(command);
-        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
+        return ResponseEntity.ok(
+                ApiResponse.of(PaymentDto.PaymentResponse.from(result))
+        );
     }
 
     @Override
-    public ResponseEntity<PaymentDto.PaymentResponse> detail(String txNo) {
+    public ResponseEntity<ApiResponse<PaymentDto.PaymentResponse>> detail(String txNo) {
         var command = new PaymentCommand.Query(txNo);
         var result = paymentUseCase.getDetail(command);
-        return ResponseEntity.ok(PaymentDto.PaymentResponse.from(result));
+        return ResponseEntity.ok(
+                ApiResponse.of(PaymentDto.PaymentResponse.from(result))
+        );
     }
 }

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1ApiSpec.java
@@ -1,5 +1,6 @@
 package com.lemonpay.wallet.interfaces.api;
 
+import com.lemonpay.common.interfaces.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,7 +26,7 @@ public interface WalletV1ApiSpec {
             summary = "지갑 충전",
             description = "지갑 충전을 통해 지갑 잔액을 증가 시킵니다."
     )
-    ResponseEntity<WalletDto.ChargeResponse> charge(
+    ResponseEntity<ApiResponse<WalletDto.ChargeResponse>> charge(
             @Parameter(description = "지갑 ID", required = true)
             @PathVariable("walletId") UUID walletId,
             @Valid @RequestBody WalletDto.ChargeRequest request);
@@ -35,7 +36,7 @@ public interface WalletV1ApiSpec {
             summary = "잔액 조회",
             description = "지갑의 현재 잔액을 조회합니다."
     )
-    ResponseEntity<WalletDto.BalancesResponse> getBalances(
+    ResponseEntity<ApiResponse<WalletDto.BalancesResponse>> getBalances(
             @Parameter(description = "지갑 ID", required = true)
             @PathVariable("walletId") UUID walletId);
 
@@ -44,7 +45,7 @@ public interface WalletV1ApiSpec {
             summary = "거래 내역 조회",
             description = "지갑의 거래 내역을 최신순으로 페이징 조회합니다. currency 파라미터가 없으면 전체 통화를 반환합니다."
     )
-    ResponseEntity<WalletDto.HistoryResponse> getHistory(
+    ResponseEntity<ApiResponse<WalletDto.HistoryResponse>> getHistory(
             @Parameter(description = "지갑 ID", required = true)
             @PathVariable("walletId") UUID walletId,
 

--- a/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
+++ b/src/main/java/com/lemonpay/wallet/interfaces/api/WalletV1Controller.java
@@ -2,6 +2,7 @@ package com.lemonpay.wallet.interfaces.api;
 
 import com.lemonpay.common.domain.Currency;
 import com.lemonpay.common.domain.Money;
+import com.lemonpay.common.interfaces.ApiResponse;
 import com.lemonpay.wallet.application.ChargeUseCase;
 import com.lemonpay.wallet.application.WalletQueryService;
 import lombok.RequiredArgsConstructor;
@@ -23,33 +24,33 @@ public class WalletV1Controller implements WalletV1ApiSpec {
     private final WalletQueryService walletQueryService;
 
     @Override
-    public ResponseEntity<WalletDto.ChargeResponse> charge(UUID walletId, WalletDto.ChargeRequest request) {
+    public ResponseEntity<ApiResponse<WalletDto.ChargeResponse>> charge(UUID walletId, WalletDto.ChargeRequest request) {
 
         Currency currency = Currency.valueOf(request.currency());
         Money money = Money.of(request.amount(), currency);
         var result = chargeUsecase.charge(walletId, money);
 
-        return ResponseEntity.ok(WalletDto.ChargeResponse.from(result));
+        return ResponseEntity.ok(ApiResponse.of(WalletDto.ChargeResponse.from(result)));
     }
 
     @Override
-    public ResponseEntity<WalletDto.BalancesResponse> getBalances(UUID walletId) {
+    public ResponseEntity<ApiResponse<WalletDto.BalancesResponse>> getBalances(UUID walletId) {
         var result = walletQueryService.getWalletBalances(walletId);
         return ResponseEntity.ok(
-                WalletDto.BalancesResponse.from(result)
+                ApiResponse.of(WalletDto.BalancesResponse.from(result))
         );
+
     }
 
     @Override
-    public ResponseEntity<WalletDto.HistoryResponse> getHistory(UUID walletId, String currency, Pageable pageable) {
-        log.warn("getHistory - walletId: {}, currency: {}, pageable: {}", walletId, currency, pageable);       Currency currencyEnum = null;
-
-        if(currency != null && !currency.isBlank()) {
+    public ResponseEntity<ApiResponse<WalletDto.HistoryResponse>> getHistory(UUID walletId, String currency, Pageable pageable) {
+        Currency currencyEnum = null;
+        if (currency != null && !currency.isBlank()) {
             currencyEnum = Currency.valueOf(currency);
         }
         var resultPage = walletQueryService.queryLedgerEntries(walletId, currencyEnum, pageable);
         return ResponseEntity.ok(
-                WalletDto.HistoryResponse.from(walletId, resultPage)
+                ApiResponse.of(WalletDto.HistoryResponse.from(walletId, resultPage))
         );
     }
 }


### PR DESCRIPTION
## 개요
  지갑/결제 API의 성공 응답 구조를 `ApiResponse` 기반 표준 포맷으로 정리했습니다.
  응답 body 최상위에 `meta`, `data`를 두어 클라이언트가 공통 방식으로 성공 응답을 처리할 수 있도록 했습니다.

  ## 변경 사항
  - 지갑 API 성공 응답을 `ApiResponse`로 감싸도록 변경
  - 결제 API 성공 응답을 `ApiResponse`로 감싸도록 변경
  - API spec과 controller 반환 타입을 `ResponseEntity<ApiResponse<T>>` 형태로 정리

  ## 설계 결정
  - 성공 응답은 `ApiResponse<T>`로 명시적으로 감싸도록 했습니다.
    - Controller에서 응답 구조가 바로 드러나 과제 코드 기준으로 흐름을 파악하기 쉽습니다.
    - Swagger/OpenAPI 문서에서도 실제 응답 wrapper 타입이 드러납니다.
  - `ResponseBodyAdvice` 기반 자동 wrapping은 이번 범위에서 제외했습니다.
    - 자동 wrapping은 반복 코드를 줄일 수 있지만, 예외 응답, 파일 응답, `String` 응답, Swagger 문서화 예외 처리가 추가로 필요합니다.
    - 현재는 명시적인 반환 타입이 더 단순하고 안전하다고 판단했습니다.
  - `ApiResponse`가 `ResponseEntity`에 직접 의존하는 helper 방식도 보류했습니다.
    - 응답 DTO가 Spring Web 타입에 의존하지 않도록 우선 단순한 `ApiResponse.of(...)`만 유지했습니다.

  ## DB 변경
  없음

  ## API 변경
  - [x] Response 변경:
    - 기존 성공 응답 body가 `ApiResponse<T>` 구조로 감싸집니다.
    - 예시:
      ```json
      {
        "meta": {
          "timestamp": "2026-05-24T15:10:30+09:00"
        },
        "data": {
          "txNo": "202605240000000001",
          "status": "PENDING"
        }
      }
      ```
  - [x] 하위 호환성:
    - 깨짐
    - 기존 클라이언트가 응답 body의 필드에 바로 접근하던 구조에서 `data` 하위로 접근하도록 수정이 필요합니다.

  ## 향후 과제
  - 반복되는 `ResponseEntity.ok(ApiResponse.of(...))` 패턴을 줄이기 위한 helper 검토
    - 별도 유틸 클래스 작성
    - 또는 `ApiResponse`의 Spring Web 의존 허용 여부 검토
  - Controller 수가 늘어나면 `ResponseBodyAdvice` 기반 자동 wrapping 검토