### PR TITLE
feat(member): 최소 회원가입 및 로그인 API 추가

### DIFF
--- a/src/main/java/com/lemonpay/config/WebConfig.java
+++ b/src/main/java/com/lemonpay/config/WebConfig.java
@@ -24,7 +24,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/**")
                 .excludePathPatterns(
                         // 인증 불필요 API (로그인, 회원가입)
-                        "/api/v1/auth/**",
+                        "/api/v1/members/login",
+                        "/api/v1/members/join",
                         // Swagger UI (dev/local 환경에서만 활성화되므로 인터셉터 제외)
                         "/swagger-ui/**",
                         "/v3/api-docs/**",

--- a/src/main/java/com/lemonpay/member/application/MemberCommand.java
+++ b/src/main/java/com/lemonpay/member/application/MemberCommand.java
@@ -1,0 +1,11 @@
+package com.lemonpay.member.application;
+
+public class MemberCommand {
+    public record Join(
+            String email,
+            String name,
+            String phone,
+            String walletName,
+            String productCode
+    ){ }
+}

--- a/src/main/java/com/lemonpay/member/application/MemberResult.java
+++ b/src/main/java/com/lemonpay/member/application/MemberResult.java
@@ -1,0 +1,39 @@
+package com.lemonpay.member.application;
+
+import com.lemonpay.member.domain.Member;
+import com.lemonpay.wallet.domain.Wallet;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class MemberResult {
+    public record CommonResult(
+            UUID memberId,
+            String email,
+            String name,
+            String phone,
+            String status,
+            UUID walletId,
+            String walletName,
+            String walletProductCode,
+            LocalDateTime createdAt,
+            LocalDateTime updateAt
+    ) {
+        public static CommonResult from(Member member, Wallet wallet) {
+            return new CommonResult(
+                    member.getId(),
+                    member.getEmail(),
+                    member.getName(),
+                    member.getPhone(),
+                    member.getStatus().name(),
+                    wallet.getId(),
+                    wallet.getName(),
+                    wallet.getProductCode(),
+                    member.getCreatedAt(),
+                    member.getUpdatedAt()
+            );
+        }
+    }
+
+
+}

--- a/src/main/java/com/lemonpay/member/application/MemberUsecase.java
+++ b/src/main/java/com/lemonpay/member/application/MemberUsecase.java
@@ -1,0 +1,31 @@
+package com.lemonpay.member.application;
+
+import com.lemonpay.member.domain.Member;
+import com.lemonpay.member.domain.MemberService;
+import com.lemonpay.wallet.domain.Wallet;
+import com.lemonpay.wallet.domain.WalletService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberUsecase {
+
+    private final MemberService memberService;
+    private final WalletService walletService;
+
+    @Transactional
+    public MemberResult.CommonResult join(MemberCommand.Join join) {
+        Member member = memberService.createMember(join.email(), join.name(), join.phone());
+        Wallet wallet = walletService.createDefaultWallet(member, join.walletName(), "BASC-V1");
+        return MemberResult.CommonResult.from(member, wallet);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberResult.CommonResult login(String email, String name) {
+        Member member = memberService.validateAccess(email, name);
+        Wallet wallet = walletService.getWalletByMemberId(member.getId());
+        return MemberResult.CommonResult.from(member, wallet);
+    }
+}

--- a/src/main/java/com/lemonpay/member/domain/MemberService.java
+++ b/src/main/java/com/lemonpay/member/domain/MemberService.java
@@ -1,0 +1,36 @@
+package com.lemonpay.member.domain;
+
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "회원 정보를 다시 확인해주세요."));
+    }
+
+    @Transactional(readOnly = true)
+    public Member validateAccess(String email, String name) {
+        Member member = getMemberByEmail(email);
+        if (!member.getName().equals(name)) {
+            throw new CoreException(ErrorType.UNAUTHORIZED, "로그인 정보가 틀렸습니다.");
+        }
+        return member;
+    }
+
+    @Transactional
+    public Member joinMember(String email, String name, String phone) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new CoreException(ErrorType.INVALID_REQUEST, "이미 존재하는 회원정보입니다.");
+        }
+        return memberRepository.save(Member.create(email, name, phone));
+    }
+}

--- a/src/main/java/com/lemonpay/member/domain/MemberService.java
+++ b/src/main/java/com/lemonpay/member/domain/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService {
     }
 
     @Transactional
-    public Member joinMember(String email, String name, String phone) {
+    public Member createMember(String email, String name, String phone) {
         if (memberRepository.existsByEmail(email)) {
             throw new CoreException(ErrorType.INVALID_REQUEST, "이미 존재하는 회원정보입니다.");
         }

--- a/src/main/java/com/lemonpay/member/interfaces/api/MemberDto.java
+++ b/src/main/java/com/lemonpay/member/interfaces/api/MemberDto.java
@@ -1,0 +1,59 @@
+package com.lemonpay.member.interfaces.api;
+
+import com.lemonpay.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "회원 관리 API 요청 및 응답 DTO")
+public class MemberDto {
+
+    @Schema(description = "회원 가입 요청")
+    public record CreationRequest(
+            @NotBlank @Email String email,
+            @NotBlank String name,
+            @NotBlank String phone
+    ) {
+    }
+
+    public record LoginRequest(
+            @NotBlank @Email String email,
+            @NotBlank String name
+    ) {
+
+    }
+
+    @Schema(description = "회원 관리 공통 응답")
+    public record MemberResponse(
+            @Schema(description = "회원의 UUID")
+            UUID id,
+            @Schema(description = "회원 이메일")
+            String email,
+            @Schema(description = "회원 이름")
+            String name,
+            @Schema(description = "회원 전화번호")
+            String phone,
+            @Schema(description = "회원 상태")
+            String status,
+            @Schema(description = "회원 가입일자/시간")
+            LocalDateTime createdAt,
+            @Schema(description = "회원 정보 변경일자/시간")
+            LocalDateTime updatedAt
+    ) {
+
+        public static MemberResponse from(Member member) {
+            return new MemberResponse(
+                    member.getId(),
+                    member.getEmail(),
+                    member.getName(),
+                    member.getPhone(),
+                    member.getStatus().name(),
+                    member.getCreatedAt(),
+                    member.getUpdatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/lemonpay/member/interfaces/api/MemberDto.java
+++ b/src/main/java/com/lemonpay/member/interfaces/api/MemberDto.java
@@ -1,6 +1,7 @@
 package com.lemonpay.member.interfaces.api;
 
-import com.lemonpay.member.domain.Member;
+import com.lemonpay.member.application.MemberCommand;
+import com.lemonpay.member.application.MemberResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -15,8 +16,19 @@ public class MemberDto {
     public record CreationRequest(
             @NotBlank @Email String email,
             @NotBlank String name,
-            @NotBlank String phone
+            @NotBlank String phone,
+            @NotBlank String walletName,
+            @NotBlank String productCode
     ) {
+        public MemberCommand.Join toCommand() {
+            return new MemberCommand.Join(
+                    email,
+                    name,
+                    phone,
+                    walletName,
+                    productCode
+            );
+        }
     }
 
     public record LoginRequest(
@@ -38,21 +50,30 @@ public class MemberDto {
             String phone,
             @Schema(description = "회원 상태")
             String status,
+            @Schema(description = "지갑 UUID")
+            UUID walletId,
+            @Schema(description = "지갑 이름")
+            String walletName,
+            @Schema(description = "지갑 상품코드")
+            String productCode,
             @Schema(description = "회원 가입일자/시간")
             LocalDateTime createdAt,
             @Schema(description = "회원 정보 변경일자/시간")
             LocalDateTime updatedAt
     ) {
 
-        public static MemberResponse from(Member member) {
+        public static MemberResponse from(MemberResult.CommonResult result) {
             return new MemberResponse(
-                    member.getId(),
-                    member.getEmail(),
-                    member.getName(),
-                    member.getPhone(),
-                    member.getStatus().name(),
-                    member.getCreatedAt(),
-                    member.getUpdatedAt()
+                    result.memberId(),
+                    result.email(),
+                    result.name(),
+                    result.phone(),
+                    result.status(),
+                    result.walletId(),
+                    result.walletName(),
+                    result.walletProductCode(),
+                    result.createdAt(),
+                    result.updateAt()
             );
         }
     }

--- a/src/main/java/com/lemonpay/member/interfaces/api/MemberV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/member/interfaces/api/MemberV1ApiSpec.java
@@ -1,4 +1,33 @@
 package com.lemonpay.member.interfaces.api;
 
+import com.lemonpay.common.interfaces.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Member V1 API Specification")
 public interface MemberV1ApiSpec {
+
+    @PostMapping("/join")
+    @Operation(
+            summary = "회원가입 요청 API",
+            description = "레몬페이 회원가입 요청 API"
+    )
+    ResponseEntity<ApiResponse<MemberDto.MemberResponse>> create(
+            @Valid @RequestBody MemberDto.CreationRequest request
+    );
+
+    @PostMapping("/login")
+    @Operation(
+            summary = "로그인 요청 API",
+            description = "레몬페이 로그인 요청 API. MVP에서는 간단하게만 구현"
+    )
+    ResponseEntity<ApiResponse<MemberDto.MemberResponse>> login(
+            @Valid @RequestBody MemberDto.LoginRequest request
+    );
+
+    // TODO 회원정보 조회 / 수정 / 탈퇴
 }

--- a/src/main/java/com/lemonpay/member/interfaces/api/MemberV1Controller.java
+++ b/src/main/java/com/lemonpay/member/interfaces/api/MemberV1Controller.java
@@ -2,8 +2,9 @@ package com.lemonpay.member.interfaces.api;
 
 
 import com.lemonpay.common.interfaces.ApiResponse;
-import com.lemonpay.member.domain.Member;
-import com.lemonpay.member.domain.MemberService;
+import com.lemonpay.member.application.MemberCommand;
+import com.lemonpay.member.application.MemberResult;
+import com.lemonpay.member.application.MemberUsecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,19 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberV1Controller implements MemberV1ApiSpec {
 
-    private final MemberService memberService;
+    private final MemberUsecase memberUsecase;
 
     @Override
     public ResponseEntity<ApiResponse<MemberDto.MemberResponse>> create(MemberDto.CreationRequest request) {
-        Member member = memberService.joinMember(request.email(), request.name(), request.phone());
+        MemberCommand.Join command = request.toCommand();
+        MemberResult.CommonResult result = memberUsecase.join(command);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(ApiResponse.of(MemberDto.MemberResponse.from(member)));
+                .body(ApiResponse.of(MemberDto.MemberResponse.from(result)));
     }
 
     @Override
     public ResponseEntity<ApiResponse<MemberDto.MemberResponse>> login(MemberDto.LoginRequest request) {
-        Member member = memberService.validateAccess(request.email(), request.name());
-        return ResponseEntity.ok(ApiResponse.of(MemberDto.MemberResponse.from(member)));
+        MemberResult.CommonResult result = memberUsecase.login(request.email(), request.name());
+        return ResponseEntity.ok(ApiResponse.of(MemberDto.MemberResponse.from(result)));
     }
 }

--- a/src/main/java/com/lemonpay/member/interfaces/api/MemberV1Controller.java
+++ b/src/main/java/com/lemonpay/member/interfaces/api/MemberV1Controller.java
@@ -1,0 +1,33 @@
+package com.lemonpay.member.interfaces.api;
+
+
+import com.lemonpay.common.interfaces.ApiResponse;
+import com.lemonpay.member.domain.Member;
+import com.lemonpay.member.domain.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberV1Controller implements MemberV1ApiSpec {
+
+    private final MemberService memberService;
+
+    @Override
+    public ResponseEntity<ApiResponse<MemberDto.MemberResponse>> create(MemberDto.CreationRequest request) {
+        Member member = memberService.joinMember(request.email(), request.name(), request.phone());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.of(MemberDto.MemberResponse.from(member)));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<MemberDto.MemberResponse>> login(MemberDto.LoginRequest request) {
+        Member member = memberService.validateAccess(request.email(), request.name());
+        return ResponseEntity.ok(ApiResponse.of(MemberDto.MemberResponse.from(member)));
+    }
+}

--- a/src/main/java/com/lemonpay/wallet/domain/WalletService.java
+++ b/src/main/java/com/lemonpay/wallet/domain/WalletService.java
@@ -2,8 +2,10 @@ package com.lemonpay.wallet.domain;
 
 import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -12,11 +14,19 @@ import java.util.UUID;
 public class WalletService {
     private final WalletRepository walletRepository;
 
+    @Transactional(readOnly = true)
     public Wallet getWallet(UUID walletId) {
         return walletRepository.findById(walletId)
                 .orElseThrow(() -> new CoreException(ErrorType.WALLET_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public Wallet getWalletByMemberId(UUID memberId) {
+        return walletRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CoreException(ErrorType.WALLET_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
     public void validateWalletAccess(UUID walletId, UUID userId) {
         if(walletId == null || userId == null) {
             throw new CoreException(ErrorType.INVALID_REQUEST, "입력값을 확인해주세요.");
@@ -26,4 +36,13 @@ public class WalletService {
             throw new CoreException(ErrorType.FORBIDDEN, "지갑 소유자가 상이합니다.");
         }
     }
+
+    @Transactional
+    public Wallet createDefaultWallet(Member member, String name, String productCode) {
+        if(walletRepository.existsByMemberId(member.getId())) {
+            throw new CoreException(ErrorType.INVALID_REQUEST, "현재는 1인당 1개의 지갑만 소유 가능합니다.");
+        }
+        return walletRepository.save(Wallet.create(member, name, productCode));
+    }
+
 }


### PR DESCRIPTION
## 개요
  프론트엔드 통합 테스트를 위해 간단한 회원가입/로그인 API를 추가했습니다.
  로그인 성공 시 이후 요청의 `X-USER-ID`로 사용할 회원 ID를 응답합니다.

  ## 변경 사항
  - 회원가입 API 추가: `POST /api/v1/members/join`
  - 로그인 API 추가: `POST /api/v1/members/login`
  - 회원가입/로그인 요청·응답 DTO 추가
  - 회원가입/로그인 경로를 `X-USER-ID` 인터셉터 제외 대상에 추가

  ## 설계 결정
  - 현재 MVP에서는 별도 인증 토큰 없이 회원 정보를 조회해 `X-USER-ID` 기반 요청 흐름을 테스트할 수 있도록 구현했습니다.
  - 로그인은 프론트엔드 연동 목적의 단순 검증으로 제한했습니다.

  ## API 변경
  - [x] 신규 엔드포인트:
    - `POST /api/v1/members/join`
    - `POST /api/v1/members/login`
  - [x] Request/Response 변경:
    - 성공 응답은 `ApiResponse<MemberResponse>` 구조로 반환
  - [x] 하위 호환성: 없음