### PR TITLE
feat(merchant): 프론트 연동용 가맹점 API 추가

### DIFF
--- a/src/main/java/com/lemonpay/config/OpenApiConfig.java
+++ b/src/main/java/com/lemonpay/config/OpenApiConfig.java
@@ -1,5 +1,6 @@
 package com.lemonpay.config;
 
+import com.lemonpay.merchant.interfaces.MerchantV1Controller;
 import com.lemonpay.wallet.interfaces.api.WalletV1Controller;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -10,7 +11,6 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.HandlerMethod;
 
 @Configuration
@@ -55,6 +55,7 @@ public class OpenApiConfig {
      */
     private boolean requiresUserIdHeaderOnDocs(HandlerMethod handlerMethod) {
         Class<?> controllerType = handlerMethod.getBeanType();
-        return controllerType == WalletV1Controller.class;
+        return controllerType == WalletV1Controller.class
+                || controllerType == MerchantV1Controller.class;
     }
 }

--- a/src/main/java/com/lemonpay/merchant/domain/MerchantRepository.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantRepository.java
@@ -1,10 +1,12 @@
 package com.lemonpay.merchant.domain;
 
 import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 
 public interface MerchantRepository {
     Merchant save(Merchant merchant);
     Optional<Merchant> findById(UUID id);
+    List<Merchant> findAll();
     boolean existsById(UUID id);
 }

--- a/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -41,6 +42,11 @@ public class MerchantService {
         }
 
         return merchantRepository.save(merchant);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Merchant> getMerchants() {
+        return merchantRepository.findAll();
     }
 
 }

--- a/src/main/java/com/lemonpay/merchant/infrastructure/MerchantRepositoryImpl.java
+++ b/src/main/java/com/lemonpay/merchant/infrastructure/MerchantRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.lemonpay.merchant.domain.MerchantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,6 +23,11 @@ public class MerchantRepositoryImpl implements MerchantRepository {
     @Override
     public Optional<Merchant> findById(UUID id) {
         return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Merchant> findAll() {
+        return jpaRepository.findAll();
     }
 
     @Override

--- a/src/main/java/com/lemonpay/merchant/interfaces/MerchantDto.java
+++ b/src/main/java/com/lemonpay/merchant/interfaces/MerchantDto.java
@@ -1,0 +1,57 @@
+package com.lemonpay.merchant.interfaces;
+
+import com.lemonpay.merchant.domain.Merchant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "가맹점 API 요청 및 응답 DTO")
+public class MerchantDto {
+
+    @Schema(description = "가맹점 생성 요청")
+    public record CreationRequest(
+            @NotBlank String name,
+            @NotBlank String callbackUrl
+    ) {
+        public Merchant toEntity() {
+            return Merchant.create(name(), callbackUrl());
+        }
+    }
+
+    @Schema(description = "가맹점 응답")
+    public record MerchantResponse(
+            UUID merchantId,
+            String name,
+            String status,
+            String callbackUrl,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        public static MerchantResponse from(Merchant merchant) {
+            return new MerchantResponse(
+                    merchant.getId(),
+                    merchant.getName(),
+                    merchant.getStatus().name(),
+                    merchant.getCallbackUrl(),
+                    merchant.getCreatedAt(),
+                    merchant.getUpdatedAt()
+            );
+        }
+    }
+
+    @Schema(description = "가맹점 목록 응답")
+    public record MerchantListResponse(
+            List<MerchantResponse> merchants
+    ) {
+        public static MerchantListResponse from(List<Merchant> merchants) {
+            return new MerchantListResponse(
+                    merchants.stream()
+                            .map(MerchantResponse::from)
+                            .toList()
+            );
+        }
+    }
+}

--- a/src/main/java/com/lemonpay/merchant/interfaces/MerchantV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/merchant/interfaces/MerchantV1ApiSpec.java
@@ -1,0 +1,43 @@
+package com.lemonpay.merchant.interfaces;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@Tag(name = "Merchant V1 API Specification")
+public interface MerchantV1ApiSpec {
+
+    @GetMapping
+    @Operation(
+            summary = "가맹점 목록 조회 API",
+            description = "등록된 가맹점 목록을 조회합니다."
+    )
+    ResponseEntity<MerchantDto.MerchantListResponse> getMerchants();
+
+    @PostMapping
+    @Operation(
+            summary = "가맹점 생성 API",
+            description = "신규 가맹점을 등록합니다."
+    )
+    ResponseEntity<MerchantDto.MerchantResponse> create(
+            @Valid @RequestBody MerchantDto.CreationRequest request
+    );
+
+    @GetMapping("/{merchantId}")
+    @Operation(
+            summary = "가맹점 단건 조회 API",
+            description = "가맹점 ID로 가맹점 상세 정보를 조회합니다."
+    )
+    ResponseEntity<MerchantDto.MerchantResponse> getMerchant(
+            @Parameter(description = "가맹점 ID", required = true)
+            @PathVariable("merchantId") UUID merchantId
+    );
+}

--- a/src/main/java/com/lemonpay/merchant/interfaces/MerchantV1Controller.java
+++ b/src/main/java/com/lemonpay/merchant/interfaces/MerchantV1Controller.java
@@ -1,0 +1,40 @@
+package com.lemonpay.merchant.interfaces;
+
+import com.lemonpay.merchant.domain.Merchant;
+import com.lemonpay.merchant.domain.MerchantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/merchants")
+@RequiredArgsConstructor
+public class MerchantV1Controller implements MerchantV1ApiSpec {
+
+    private final MerchantService merchantService;
+
+    @Override
+    public ResponseEntity<MerchantDto.MerchantListResponse> getMerchants() {
+        List<Merchant> merchants = merchantService.getMerchants();
+        return ResponseEntity.ok(MerchantDto.MerchantListResponse.from(merchants));
+    }
+
+    @Override
+    public ResponseEntity<MerchantDto.MerchantResponse> create(MerchantDto.CreationRequest request) {
+        Merchant merchant = merchantService.register(request.toEntity());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(MerchantDto.MerchantResponse.from(merchant));
+    }
+
+    @Override
+    public ResponseEntity<MerchantDto.MerchantResponse> getMerchant(UUID merchantId) {
+        Merchant merchant = merchantService.getMerchantById(merchantId);
+        return ResponseEntity.ok(MerchantDto.MerchantResponse.from(merchant));
+    }
+}


### PR DESCRIPTION
## 개요
  프론트엔드 결제 요청 화면에서 사용할 가맹점 REST API를 추가했습니다.
  가맹점 목록 조회, 생성, 단건 조회를 통해 결제 요청에 필요한 `merchantId`와 가맹점 정보를 조회할 수 있습니다.

  ## 변경 사항
  - 가맹점 목록/생성/단건 조회 API 구현
  - 결제 요청 화면에서 사용할 가맹점 응답 DTO 추가
  - Swagger `X-USER-ID` 헤더 대상에 가맹점 컨트롤러 추가
  - 가맹점 목록 조회를 위한 repository/service 메서드 추가

  ## 설계 결정
  - 현재 MVP에서는 가맹점 API를 목록 조회, 생성, 단건 조회로 최소화했습니다.
  - 응답에는 Entity를 직접 반환하지 않고 별도 DTO를 사용했습니다.
  - 가맹점 API도 기존 `/api/**` 인터셉터 대상이므로 Swagger 문서에서 `X-USER-ID` 헤더가 표시되도록 했습니다.

  ## DB 변경
  - 없음

  ## API 변경
  - [x] 신규 엔드포인트:
    - `GET /api/v1/merchants`
    - `POST /api/v1/merchants`
    - `GET /api/v1/merchants/{merchantId}`
  - [x] Request/Response 변경:
    - 가맹점 생성 요청 DTO 추가
    - 가맹점 단건/목록 응답 DTO 추가
  - [x] 하위 호환성: 유지
    - 기존 엔드포인트 변경 없음

  ## 테스트
- 없음

  ## 체크리스트
  - [x] 빌드 성공 (`./gradlew build`)
  - [x] 민감 정보 로깅 없음 (계좌번호, 잔액 등)
  - [x] API 응답에 내부 구현 노출 없음 (Entity 직접 반환 금지)