### PR TITLE
fix: 가맹점 등록 시 이름 기준 중복 검증 적용

### DIFF
--- a/src/main/java/com/lemonpay/merchant/domain/MerchantRepository.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantRepository.java
@@ -9,4 +9,5 @@ public interface MerchantRepository {
     Optional<Merchant> findById(UUID id);
     List<Merchant> findAll();
     boolean existsById(UUID id);
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
+++ b/src/main/java/com/lemonpay/merchant/domain/MerchantService.java
@@ -2,6 +2,7 @@ package com.lemonpay.merchant.domain;
 
 import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,8 +30,8 @@ public class MerchantService {
 
     @Transactional
     public Merchant register(Merchant merchant) {
-        if(merchantRepository.existsById(merchant.getId())) {
-            throw new CoreException(ErrorType.INVALID_REQUEST, "이미 등록된 가맹점입니다.");
+        if(merchantRepository.existsByName(merchant.getName())) {
+            throw new CoreException(ErrorType.INVALID_REQUEST, "이미 존재하는 가맹점입니다.");
         }
         return merchantRepository.save(merchant);
     }

--- a/src/main/java/com/lemonpay/merchant/infrastructure/MerchantJpaRepository.java
+++ b/src/main/java/com/lemonpay/merchant/infrastructure/MerchantJpaRepository.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 
 public interface MerchantJpaRepository extends JpaRepository<Merchant, UUID> {
 
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/lemonpay/merchant/infrastructure/MerchantRepositoryImpl.java
+++ b/src/main/java/com/lemonpay/merchant/infrastructure/MerchantRepositoryImpl.java
@@ -34,4 +34,9 @@ public class MerchantRepositoryImpl implements MerchantRepository {
     public boolean existsById(UUID id) {
         return jpaRepository.existsById(id);
     }
+
+    @Override
+    public boolean existsByName(String name) {
+        return jpaRepository.existsByName(name);
+    }
 }


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
가맹점 등록시 save 시점에 생성되는 id로 중복 체크하려고 하여 문제가 발생하여 중복 검증 키를 변경.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
- 가맹점 등록 시 이름 기준 중복 검증 적용
-

## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->


## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- [x] 하위 호환성: 유지 

## 테스트
- 해당없음

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과

## 관련 이슈
<!-- Closes #이슈번호 -->

## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
