### PR TITLE
feat(exchange): 환율 Provider 연동과 조회/동기화 기능 구현

### DIFF
--- a/docs/classDiagram/01-ExchangeProvider.mermaid
+++ b/docs/classDiagram/01-ExchangeProvider.mermaid
@@ -1,0 +1,81 @@
+classDiagram
+    direction LR
+
+    namespace exchange_application {
+        class ExchangeRateProvider {
+            <<interface>>
+            +ExchangeRateSnapshot fetch()
+        }
+
+        class ExchangeRateSnapshot {
+            <<record>>
+        }
+    }
+
+    namespace exchange_infrastructure_provider_stub {
+        class StubExchangeRateProvider {
+            +ExchangeRateSnapshot fetch()
+        }
+    }
+
+    namespace exchange_infrastructure_provider_exchangeapi {
+        class ExchangeRateApiAdapter {
+            -RestClient exchangeRateRestClient
+            -ExchangeRateApiProperties properties
+            +ExchangeRateSnapshot fetch(Currency, Currency, LocalDate)
+            -ExchangeRateApiResponse requestLatestRates(Currency)
+            -void validateSuccess(ExchangeRateApiResponse)
+        }
+
+        class ExchangeRateApiConfig {
+            <<Config>>
+            +exchangeRateRestClient(builder, properties) RestClient
+        }
+
+        class ExchangeRateApiProperties {
+            <<ConfigurationProperties>>
+            -String baseUrl
+            -String apiKey
+            +boolean hasApiKey()
+        }
+
+        class ExchangeRateApiResponse {
+            <<external api dto>>
+            -String result
+            -String baseCode
+            -Map~String, BigDecimal~ conversionRates
+            -String errorType
+            +boolean isSuccess()
+            +Optional~BigDecimal~ rateOf(Currency)
+        }
+    }
+
+    namespace spring {
+        class RestClient {
+            <<Spring Bean>>
+        }
+    }
+
+    ExchangeRateProvider <|.. StubExchangeRateProvider : implements
+    ExchangeRateProvider <|.. ExchangeRateApiAdapter : implements
+
+    ExchangeRateApiConfig ..> ExchangeRateApiProperties : uses
+    ExchangeRateApiConfig ..> RestClient : creates
+
+    ExchangeRateApiAdapter --> RestClient : uses
+    ExchangeRateApiAdapter --> ExchangeRateApiProperties : uses
+    ExchangeRateApiAdapter ..> ExchangeRateApiResponse : maps response
+
+    ExchangeRateApiAdapter ..> ExchangeRateSnapshot : returns
+    StubExchangeRateProvider ..> ExchangeRateSnapshot : returns
+
+    %% note for ExchangeRateApiProperties "1. YAML exchange.rate-api.* 값이 바인딩된다."
+    %% note for ExchangeRateApiConfig "2. Properties 값을 사용해 RestClient Bean을 생성한다."
+    %% note for RestClient "3. Spring Container에 exchangeRateRestClient Bean으로 등록된다."
+    %% note for ExchangeRateApiAdapter "4. Adapter는 RestClient와 Properties를 주입받아 외부 API를 호출한다."
+    %% note for ExchangeRateApiResponse "exchangerate-api.com 응답 포맷에 종속된 infrastructure DTO. application/domain으로 노출하지 않는다."
+
+    %% package mapping
+    %% exchange_application = com.lemonpay.exchange.application
+    %% exchange_infrastructure_provider = com.lemonpay.exchange.infrastructure.provider
+    %% exchange_infrastructure_provider_exchangeapi = com.lemonpay.exchange.infrastructure.provider.exchangeapi

--- a/docs/classDiagram/02-ExchangeRateConditionalSync.mermaid
+++ b/docs/classDiagram/02-ExchangeRateConditionalSync.mermaid
@@ -1,0 +1,100 @@
+classDiagram
+    direction LR
+
+    %% syncIfStale()
+    %%   -> master 조회
+    %%   -> isFresh() == true
+    %%       -> ExchangeRateSyncResult.skipped()
+    %%   -> 없거나 stale
+    %%       -> syncExchangeRate()
+    %%       -> provider fetch
+    %%       -> history save
+    %%       -> master upsert
+    %%       -> ExchangeRateSyncResult.synced()
+
+    namespace exchange_application {
+        class ExchangeRateSyncUseCase {
+            -ExchangeRateProvider exchangeRateProvider
+            -ExchangeRateRepository exchangeRateRepository
+            -ExchangeRateHistoryRepository exchangeRateHistoryRepository
+            -ExchangeRateProperties exchangeRateProperties
+            +syncExchangeRate(baseCurrency, targetCurrency) ExchangeRateSnapshot
+            +syncIfStale(baseCurrency, targetCurrency) ExchangeRateSyncResult
+            -upsertExchangeRate(snapshot) ExchangeRate
+            -isFresh(rate) boolean
+        }
+
+        class ExchangeRateProvider {
+            <<interface>>
+            +fetch(baseCurrency, targetCurrency, rateDate) ExchangeRateSnapshot
+        }
+
+        class ExchangeRateSnapshot {
+            +from(exchangeRate) ExchangeRateSnapshot
+            +toExchangeRate() ExchangeRate
+            +toOfficialHistory() ExchangeRateHistory
+        }
+
+        class ExchangeRateSyncResult {
+            -ExchangeRateSyncStatus status
+            -ExchangeRateSnapshot snapshot
+            -String reason
+            +synced(snapshot) ExchangeRateSyncResult
+            +skipped(snapshot, reason) ExchangeRateSyncResult
+        }
+
+        class ExchangeRateSyncStatus {
+            <<enumeration>>
+            SYNCED
+            SKIPPED
+        }
+    }
+
+    namespace exchange_domain {
+        class ExchangeRate {
+            +update(rate, rateDate, roundNo, rateType, source, fetchedAt)
+            +getFetchedAt() LocalDateTime
+        }
+
+        class ExchangeRateHistory {
+        }
+
+        class ExchangeRateRepository {
+            <<interface>>
+            +findByCurrencyPair(baseCurrency, targetCurrency) Optional~ExchangeRate~
+            +save(exchangeRate) ExchangeRate
+        }
+
+        class ExchangeRateHistoryRepository {
+            <<interface>>
+            +save(history) ExchangeRateHistory
+        }
+    }
+
+    namespace exchange_infrastructure_config {
+        class ExchangeRateProperties {
+            <<ConfigurationProperties>>
+            -String provider
+            -long syncTtlMinutes
+        }
+    }
+
+    ExchangeRateSyncUseCase --> ExchangeRateProvider : fetches when stale
+    ExchangeRateSyncUseCase --> ExchangeRateRepository : reads/upserts master
+    ExchangeRateSyncUseCase --> ExchangeRateHistoryRepository : appends history
+    ExchangeRateSyncUseCase --> ExchangeRateProperties : reads TTL
+    ExchangeRateSyncUseCase --> ExchangeRateSyncResult : returns
+    ExchangeRateSyncUseCase --> ExchangeRateSnapshot : creates/uses
+
+    ExchangeRateSyncResult --> ExchangeRateSyncStatus : has
+    ExchangeRateSyncResult --> ExchangeRateSnapshot : has
+
+    ExchangeRateSnapshot --> ExchangeRate : from/to
+    ExchangeRateSnapshot --> ExchangeRateHistory : toOfficialHistory
+
+    ExchangeRateRepository --> ExchangeRate : manages
+    ExchangeRateHistoryRepository --> ExchangeRateHistory : manages
+
+    %%
+
+    %%

--- a/docs/sequenceDiagrams/03-ExchangeRateSyncUsecase.mermaid
+++ b/docs/sequenceDiagrams/03-ExchangeRateSyncUsecase.mermaid
@@ -1,0 +1,35 @@
+sequenceDiagram
+    actor C as Client/Scheduler
+    participant U as ExchangeRateSyncUseCase
+    participant P as ExchangeRateProvider
+    participant API as 외부 API
+    participant H as ExchangeRateHistoryRepository
+    participant M as ExchangeRateRepository
+
+    C ->>+ U: sync(baseCurrency, targetCurrency, rateDate)
+
+    U ->>+ P: fetch(baseCurrency, targetCurrency, rateDate)
+    P ->>+ API: HTTP API call
+    API -->>- P: HTTP response
+    P ->> P: ExchangeRateSnapshot 변환
+    P -->>- U: ExchangeRateSnapshot
+
+    U ->>+ M: findByCurrencyPair(baseCurrency, targetCurrency)
+    M -->>- U: Optional<ExchangeRate>
+
+    activate U
+    U ->> U: ExchangeRateHistory.official(snapshot)
+    alt currentRate exists
+        U ->> U: currentRate.update(snapshot)
+    else currentRate empty
+        U ->> U: ExchangeRate.create(snapshot)
+    end
+    deactivate U
+
+    U ->>+ H: save(history)
+    H -->>- U: savedHistory
+
+    U ->>+ M: save(exchangeRate)
+    M -->>- U: savedRate
+
+    U -->>- C: ExchangeRateSyncResult

--- a/src/main/java/com/lemonpay/config/WebConfig.java
+++ b/src/main/java/com/lemonpay/config/WebConfig.java
@@ -27,6 +27,7 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/v1/members/login",
                         "/api/v1/members/join",
                         "/api/v1/merchants/**",
+                        "/api/v1/exchange-rates/**",
                         // Swagger UI (dev/local 환경에서만 활성화되므로 인터셉터 제외)
                         "/swagger-ui/**",
                         "/v3/api-docs/**",

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateProvider.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateProvider.java
@@ -1,0 +1,14 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+
+import java.time.LocalDate;
+
+public interface ExchangeRateProvider {
+
+    ExchangeRateSnapshot fetch(
+            Currency baseCurrency,
+            Currency targetCurrency,
+            LocalDate rateDate
+    );
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateQueryService.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateQueryService.java
@@ -1,0 +1,37 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.exchange.domain.ExchangeRate;
+import com.lemonpay.exchange.domain.ExchangeRateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeRateQueryService {
+    private final ExchangeRateRepository exchangeRateRepository;
+
+    @Transactional(readOnly = true)
+    public ExchangeRateSnapshot getLatestExchangeRate(Currency baseCurrency, Currency targetCurrency) {
+        ExchangeRate exchangeRate = exchangeRateRepository.findByCurrencyPair(baseCurrency, targetCurrency)
+                .orElseThrow(() -> new CoreException(
+                        ErrorType.NOT_FOUND,
+                        "환율 정보를 찾을 수 없습니다: %s/%s ".formatted(baseCurrency, targetCurrency))
+                );
+        return ExchangeRateSnapshot.from(exchangeRate);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExchangeRateSnapshot> getLatestExchangeRates() {
+        return exchangeRateRepository.findAll()
+                .stream()
+                .map(ExchangeRateSnapshot::from)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
@@ -1,0 +1,63 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.ExchangeRate;
+import com.lemonpay.exchange.domain.ExchangeRateHistory;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record ExchangeRateSnapshot(
+        Currency baseCurrency,
+        Currency targetCurrency,
+        BigDecimal rate,
+        LocalDate rateDate,
+        int roundNo,
+        ExchangeRateType rateType,
+        ExchangeRateSource source,
+        LocalDateTime fetchedAt
+) {
+
+    public ExchangeRateSnapshot {
+        Objects.requireNonNull(baseCurrency, "기준 통화는 필수입니다.");
+        Objects.requireNonNull(targetCurrency, "대상 통화는 필수입니다.");
+        Objects.requireNonNull(rate, "환율은 필수입니다.");
+        Objects.requireNonNull(rateDate, "환율 기준일은 필수입니다.");
+        Objects.requireNonNull(rateType, "환율 유형은 필수입니다.");
+        Objects.requireNonNull(source, "환율 출처는 필수입니다.");
+        Objects.requireNonNull(fetchedAt, "환율 조회 시각은 필수입니다.");
+    }
+
+    public ExchangeRate toExchangeRate() {
+        return ExchangeRate.create(
+                baseCurrency,
+                targetCurrency,
+                rate,
+                rateDate,
+                roundNo,
+                rateType,
+                source,
+                fetchedAt
+        );
+    }
+
+    public ExchangeRateHistory toOfficialHistory() {
+        if (rateType != ExchangeRateType.OFFICIAL) {
+            throw new IllegalStateException("공식 환율 스냅샷만 공식 환율 이력으로 변환할 수 있습니다.");
+        }
+
+        return ExchangeRateHistory.official(
+                baseCurrency,
+                targetCurrency,
+                rate,
+                rateDate,
+                roundNo,
+                source,
+                fetchedAt
+        );
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
@@ -60,4 +60,17 @@ public record ExchangeRateSnapshot(
                 fetchedAt
         );
     }
+
+    public static ExchangeRateSnapshot from(ExchangeRate exchangeRate) {
+        return new ExchangeRateSnapshot(
+                exchangeRate.getBaseCurrency(),
+                exchangeRate.getTargetCurrency(),
+                exchangeRate.getRate(),
+                exchangeRate.getRateDate(),
+                exchangeRate.getRoundNo(),
+                exchangeRate.getRateType(),
+                exchangeRate.getSource(),
+                exchangeRate.getFetchedAt()
+        );
+    }
 }

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncResult.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncResult.java
@@ -1,0 +1,29 @@
+package com.lemonpay.exchange.application;
+
+import java.util.Objects;
+
+public record ExchangeRateSyncResult(
+        ExchangeRateSyncStatus status,
+        ExchangeRateSnapshot snapshot,
+        String reason
+) {
+
+    public ExchangeRateSyncResult {
+        Objects.requireNonNull(status, "환율 동기화 상태는 필수입니다.");
+        Objects.requireNonNull(snapshot, "환율 스냅샷은 필수입니다.");
+        Objects.requireNonNull(reason, "환율 동기화 사유는 필수입니다.");
+    }
+
+    public static ExchangeRateSyncResult synced(ExchangeRateSnapshot snapshot) {
+        return new ExchangeRateSyncResult(ExchangeRateSyncStatus.SYNCED,
+                snapshot,
+                ExchangeRateSyncStatus.SYNCED.name()
+        );
+    }
+
+    public static ExchangeRateSyncResult skipped(ExchangeRateSnapshot snapshot,
+                                                 String reason) {
+        return new ExchangeRateSyncResult(ExchangeRateSyncStatus.SKIPPED, snapshot, reason);
+    }
+
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncStatus.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncStatus.java
@@ -1,0 +1,6 @@
+package com.lemonpay.exchange.application;
+
+public enum ExchangeRateSyncStatus {
+    SYNCED,
+    SKIPPED
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
@@ -1,0 +1,51 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.ExchangeRate;
+import com.lemonpay.exchange.domain.ExchangeRateHistory;
+import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
+import com.lemonpay.exchange.domain.ExchangeRateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeRateSyncUseCase {
+
+    private final ExchangeRateProvider exchangeRateProvider;
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+
+    @Transactional
+    public ExchangeRateSnapshot syncExchangeRate(Currency baseCurrency, Currency targetCurrency) {
+        LocalDate baseDate = LocalDate.now();
+        ExchangeRateSnapshot snapshot = exchangeRateProvider.fetch(baseCurrency, targetCurrency, baseDate);
+
+        ExchangeRateHistory exchangeRateHistory = snapshot.toOfficialHistory();
+        exchangeRateHistoryRepository.save(exchangeRateHistory);
+        upsertExchangeRate(snapshot);
+
+        return snapshot;
+    }
+
+    private ExchangeRate upsertExchangeRate(ExchangeRateSnapshot snapshot) {
+        ExchangeRate exchangeRate = exchangeRateRepository.findByCurrencyPair(snapshot.baseCurrency(), snapshot.targetCurrency())
+                .map(found -> {
+                            found.update(
+                                    snapshot.rate(),
+                                    snapshot.rateDate(),
+                                    snapshot.roundNo(),
+                                    snapshot.rateType(),
+                                    snapshot.source(),
+                                    snapshot.fetchedAt()
+                            );
+                            return found;
+                        }
+                ).orElseGet(snapshot::toExchangeRate);
+
+        return exchangeRateRepository.save(exchangeRate);
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
@@ -5,11 +5,13 @@ import com.lemonpay.exchange.domain.ExchangeRate;
 import com.lemonpay.exchange.domain.ExchangeRateHistory;
 import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
 import com.lemonpay.exchange.domain.ExchangeRateRepository;
+import com.lemonpay.exchange.infrastructure.config.ExchangeRateProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +20,7 @@ public class ExchangeRateSyncUseCase {
     private final ExchangeRateProvider exchangeRateProvider;
     private final ExchangeRateRepository exchangeRateRepository;
     private final ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+    private final ExchangeRateProperties exchangeRateProperties;
 
     @Transactional
     public ExchangeRateSnapshot syncExchangeRate(Currency baseCurrency, Currency targetCurrency) {
@@ -29,6 +32,19 @@ public class ExchangeRateSyncUseCase {
         upsertExchangeRate(snapshot);
 
         return snapshot;
+    }
+
+    @Transactional
+    public ExchangeRateSyncResult syncIfStale(Currency baseCurrency, Currency targetCurrency) {
+        return exchangeRateRepository.findByCurrencyPair(baseCurrency, targetCurrency)
+                .filter(this::isFresh)
+                .map(rate -> ExchangeRateSyncResult.skipped(
+                        ExchangeRateSnapshot.from(rate),
+                        "환율 정보가 TTL 이내로 skip 합니다."
+                ))
+                .orElseGet(() -> ExchangeRateSyncResult.synced(
+                        syncExchangeRate(baseCurrency, targetCurrency)
+                ));
     }
 
     private ExchangeRate upsertExchangeRate(ExchangeRateSnapshot snapshot) {
@@ -47,5 +63,10 @@ public class ExchangeRateSyncUseCase {
                 ).orElseGet(snapshot::toExchangeRate);
 
         return exchangeRateRepository.save(exchangeRate);
+    }
+
+    private boolean isFresh(ExchangeRate rate) {
+        return rate.getFetchedAt()
+                .isAfter(LocalDateTime.now().minusMinutes(exchangeRateProperties.syncTtlMinutes()));
     }
 }

--- a/src/main/java/com/lemonpay/exchange/domain/ExchangeRate.java
+++ b/src/main/java/com/lemonpay/exchange/domain/ExchangeRate.java
@@ -2,6 +2,7 @@ package com.lemonpay.exchange.domain;
 
 import com.lemonpay.common.domain.BaseEntity;
 import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -118,6 +119,33 @@ public class ExchangeRate extends BaseEntity {
         this.rateType = Objects.requireNonNull(rateType, "환율 유형은 필수입니다.");
         this.source = Objects.requireNonNull(source, "환율 출처는 필수입니다.");
         this.fetchedAt = Objects.requireNonNull(fetchedAt, "환율 조회 시각은 필수입니다.");
+    }
+
+    public Money convertBaseToTarget(Money baseMoney) {
+        Objects.requireNonNull(baseMoney, "변환할 금액은 필수입니다.");
+        if (baseMoney.currency() != this.baseCurrency) {
+            throw new IllegalArgumentException(
+                    "환율 기준 통화와 금액 통화가 일치하지 않습니다: %s/%s"
+                            .formatted(this.baseCurrency, baseMoney.currency())
+            );
+        }
+
+        BigDecimal convertedAmount = baseMoney.amount().multiply(this.rate);
+        return Money.of(convertedAmount, this.targetCurrency);
+    }
+
+    public Money convertTargetToBase(Money targetMoney) {
+        Objects.requireNonNull(targetMoney, "변환할 금액은 필수입니다.");
+        if (targetMoney.currency() != this.targetCurrency) {
+            throw new IllegalArgumentException(
+                    "환율 대상 통화와 금액 통화가 일치하지 않습니다: %s/%s"
+                            .formatted(this.targetCurrency, targetMoney.currency())
+            );
+        }
+
+        BigDecimal convertedAmount = targetMoney.amount()
+                .divide(this.rate, RATE_SCALE, RoundingMode.HALF_UP);
+        return Money.of(convertedAmount, this.baseCurrency);
     }
 
     private static void validateCurrencyPair(Currency baseCurrency, Currency targetCurrency) {

--- a/src/main/java/com/lemonpay/exchange/domain/ExchangeRateRepository.java
+++ b/src/main/java/com/lemonpay/exchange/domain/ExchangeRateRepository.java
@@ -2,6 +2,7 @@ package com.lemonpay.exchange.domain;
 
 import com.lemonpay.common.domain.Currency;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ExchangeRateRepository {
@@ -9,4 +10,6 @@ public interface ExchangeRateRepository {
     ExchangeRate save(ExchangeRate exchangeRate);
 
     Optional<ExchangeRate> findByCurrencyPair(Currency baseCurrency, Currency targetCurrency);
+
+    List<ExchangeRate> findAll();
 }

--- a/src/main/java/com/lemonpay/exchange/infrastructure/ExchangeRateRepositoryImpl.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/ExchangeRateRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.lemonpay.exchange.domain.ExchangeRateRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -22,5 +23,10 @@ public class ExchangeRateRepositoryImpl implements ExchangeRateRepository {
     @Override
     public Optional<ExchangeRate> findByCurrencyPair(Currency baseCurrency, Currency targetCurrency) {
         return jpaRepository.findByBaseCurrencyAndTargetCurrency(baseCurrency, targetCurrency);
+    }
+
+    @Override
+    public List<ExchangeRate> findAll() {
+        return jpaRepository.findAll();
     }
 }

--- a/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateConfig.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateConfig.java
@@ -1,0 +1,10 @@
+package com.lemonpay.exchange.infrastructure.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({ExchangeRateProperties.class, ExchangeRateSchedulerProperties.class})
+public class ExchangeRateConfig {
+
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateProperties.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateProperties.java
@@ -1,0 +1,10 @@
+package com.lemonpay.exchange.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "exchange.rate")
+public record ExchangeRateProperties(
+        String provider,
+        long syncTtlMinutes
+) {
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateSchedulerProperties.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateSchedulerProperties.java
@@ -1,0 +1,13 @@
+package com.lemonpay.exchange.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "exchange.rate.scheduler")
+public record ExchangeRateSchedulerProperties(
+        boolean enabled,
+        String cron,
+        List<String> pairs
+) {
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateSchedulingConfig.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateSchedulingConfig.java
@@ -1,0 +1,14 @@
+package com.lemonpay.exchange.infrastructure.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(
+        name = "exchange.rate.scheduler.enabled",
+        havingValue = "true"
+)
+public class ExchangeRateSchedulingConfig {
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiAdapter.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiAdapter.java
@@ -1,0 +1,84 @@
+package com.lemonpay.exchange.infrastructure.provider.exchangeapi;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.exception.CoreException;
+import com.lemonpay.common.exception.ErrorType;
+import com.lemonpay.exchange.application.ExchangeRateProvider;
+import com.lemonpay.exchange.application.ExchangeRateSnapshot;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "exchange.rate.provider",
+        havingValue = "api"
+)
+public class ExchangeRateApiAdapter implements ExchangeRateProvider {
+
+    private final RestClient exchangeRateRestClient;
+    private final ExchangeRateApiProperties properties;
+
+    @Override
+    public ExchangeRateSnapshot fetch(Currency baseCurrency, Currency targetCurrency, LocalDate rateDate) {
+        if (!properties.hasApiKey()) {
+            throw new CoreException(ErrorType.INVALID_REQUEST, "환율 API Key가 설정되지 않았습니다.");
+        }
+
+        ExchangeRateApiResponse response = requestLatestRates(baseCurrency);
+        validateSuccess(response);
+
+        BigDecimal rate = response.rateOf(targetCurrency)
+                .orElseThrow(() -> new CoreException(
+                        ErrorType.NOT_FOUND,
+                        "대상 통화 환율을 찾을 수 없습니다: %s/%s".formatted(baseCurrency, targetCurrency)
+                ));
+
+        return new ExchangeRateSnapshot(
+                baseCurrency,
+                targetCurrency,
+                rate,
+                rateDate,
+                1,
+                ExchangeRateType.OFFICIAL,
+                ExchangeRateSource.API,
+                LocalDateTime.now()
+        );
+    }
+
+    private ExchangeRateApiResponse requestLatestRates(Currency baseCurrency) {
+        try {
+            return exchangeRateRestClient.get()
+                    .uri("/v6/{apiKey}/latest/{baseCurrency}", properties.apiKey(), baseCurrency.name())
+                    .retrieve()
+                    .body(ExchangeRateApiResponse.class);
+        } catch (RestClientException e) {
+            throw new CoreException(
+                    ErrorType.INTERNAL_SERVER_ERROR,
+                    "외부 환율 API 호출에 실패했습니다."
+            );
+        }
+    }
+
+    private void validateSuccess(ExchangeRateApiResponse response) {
+        if (response == null) {
+            throw new CoreException(ErrorType.INTERNAL_SERVER_ERROR, "환율 API 응답이 비어 있습니다.");
+        }
+
+        if (!response.isSuccess()) {
+            throw new CoreException(
+                    ErrorType.INTERNAL_SERVER_ERROR,
+                    "환율 API 오류 응답: %s".formatted(response.errorType())
+            );
+        }
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiConfig.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiConfig.java
@@ -1,0 +1,21 @@
+package com.lemonpay.exchange.infrastructure.provider.exchangeapi;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(ExchangeRateApiProperties.class)
+public class ExchangeRateApiConfig {
+
+    @Bean
+    public RestClient exchangeRateRestClient(
+            RestClient.Builder builder,
+            ExchangeRateApiProperties properties
+    ) {
+        return builder
+                .baseUrl(properties.baseUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiProperties.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiProperties.java
@@ -1,0 +1,15 @@
+package com.lemonpay.exchange.infrastructure.provider.exchangeapi;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties(prefix = "exchange.rate-api")
+public record ExchangeRateApiProperties(
+        String baseUrl,
+        String apiKey
+) {
+
+    public boolean hasApiKey() {
+        return StringUtils.hasText(apiKey);
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiResponse.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiResponse.java
@@ -1,0 +1,30 @@
+package com.lemonpay.exchange.infrastructure.provider.exchangeapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.lemonpay.common.domain.Currency;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Optional;
+
+record ExchangeRateApiResponse(
+        String result,
+        @JsonProperty("base_code")
+        String baseCode,
+        @JsonProperty("conversion_rates")
+        Map<String, BigDecimal> conversionRates,
+        @JsonProperty("error-type")
+        String errorType
+) {
+
+    boolean isSuccess() {
+        return "success".equals(result);
+    }
+
+    Optional<BigDecimal> rateOf(Currency targetCurrency) {
+        if (conversionRates == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(conversionRates.get(targetCurrency.name()));
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/provider/stub/StubExchangeRateProvider.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/provider/stub/StubExchangeRateProvider.java
@@ -1,0 +1,51 @@
+package com.lemonpay.exchange.infrastructure.provider.stub;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.application.ExchangeRateProvider;
+import com.lemonpay.exchange.application.ExchangeRateSnapshot;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Component
+@ConditionalOnProperty(
+        name = "exchange.rate.provider",
+        havingValue = "stub"
+)
+public class StubExchangeRateProvider implements ExchangeRateProvider {
+
+    private static final Map<CurrencyPair, BigDecimal> RATES = Map.of(
+            new CurrencyPair(Currency.USD, Currency.KRW), new BigDecimal("1350.00000000"),
+            new CurrencyPair(Currency.JPY, Currency.KRW), new BigDecimal("9.20000000")
+    );
+
+    @Override
+    public ExchangeRateSnapshot fetch(Currency baseCurrency, Currency targetCurrency, LocalDate rateDate) {
+        BigDecimal rate = RATES.get(new CurrencyPair(baseCurrency, targetCurrency));
+        if (rate == null) {
+            throw new IllegalArgumentException(
+                    "Stub 환율을 지원하지 않는 통화쌍입니다: %s/%s"
+                            .formatted(baseCurrency, targetCurrency)
+            );
+        }
+
+        return new ExchangeRateSnapshot(
+                baseCurrency,
+                targetCurrency,
+                rate,
+                rateDate,
+                1,
+                ExchangeRateType.OFFICIAL,
+                ExchangeRateSource.API,
+                LocalDateTime.now()
+        );
+    }
+
+    private record CurrencyPair(Currency baseCurrency, Currency targetCurrency) { }
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateScheduler.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateScheduler.java
@@ -1,0 +1,52 @@
+package com.lemonpay.exchange.infrastructure.scheduler;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.application.ExchangeRateSyncResult;
+import com.lemonpay.exchange.application.ExchangeRateSyncUseCase;
+import com.lemonpay.exchange.infrastructure.config.ExchangeRateSchedulerProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(
+        name = "exchange.rate.scheduler.enabled",
+        havingValue = "true"
+)
+@RequiredArgsConstructor
+public class ExchangeRateScheduler {
+    private final ExchangeRateSchedulerProperties properties;
+    private final ExchangeRateSyncUseCase syncUseCase;
+
+    @Scheduled(cron = "${exchange.rate.scheduler.cron}")
+    public void syncExchangeRate() {
+        if(!properties.enabled()) return;
+
+        for(String pairStr : properties.pairs()) {
+            CurrencyPair pair = parseToCurrencyPair(pairStr);
+
+            ExchangeRateSyncResult result = syncUseCase.syncIfStale(pair.baseCurrency, pair.targetCurrency);
+
+            log.info("exchange rate sync result: pair={}/{}, status={}, reason={}",
+                    pair.baseCurrency(),
+                    pair.targetCurrency(),
+                    result.status(),
+                    result.reason());
+        }
+    }
+
+    private record CurrencyPair(Currency baseCurrency, Currency targetCurrency) { }
+
+    private CurrencyPair parseToCurrencyPair(String pair) {
+        String[] split = pair.split("/");
+        if(split.length != 2) {
+            throw new IllegalArgumentException("Invalid pair: " + pair);
+        }
+        Currency base = Currency.valueOf(split[0]);
+        Currency target = Currency.valueOf(split[1]);
+        return new CurrencyPair(base, target);
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/interfaces/ExchangeRateDto.java
+++ b/src/main/java/com/lemonpay/exchange/interfaces/ExchangeRateDto.java
@@ -1,0 +1,62 @@
+package com.lemonpay.exchange.interfaces;
+
+import com.lemonpay.exchange.application.ExchangeRateSnapshot;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "환율 조회 API 요청 및 응답 DTO")
+public class ExchangeRateDto {
+
+    @Schema(description = "환율 조회 API 요청 DTO")
+    public record RateRequest(
+            @NotBlank String baseCurrency,
+            @NotBlank String targetCurrency
+    ) { }
+
+    /**
+     * @see com.lemonpay.exchange.application.ExchangeRateSnapshot
+     * @param baseCurrency
+     * @param targetCurrency
+     * @param rate
+     * @param rateDate
+     * @param roundNo
+     * @param rateType
+     * @param source
+     * @param fetchedAt
+     */
+    @Schema(description = "환율 조회 API 응답 DTO")
+    public record RateResponse(
+            String baseCurrency,
+            String targetCurrency,
+            BigDecimal rate,
+            LocalDate rateDate,
+            int roundNo,
+            String rateType,
+            String source,
+            LocalDateTime fetchedAt
+    ) {
+        public static RateResponse from(ExchangeRateSnapshot snapshot) {
+            return new RateResponse(
+                    snapshot.baseCurrency().getCode(),
+                    snapshot.targetCurrency().getCode(),
+                    snapshot.rate(),
+                    snapshot.rateDate(),
+                    snapshot.roundNo(),
+                    snapshot.rateType().name(),
+                    snapshot.source().name(),
+                    snapshot.fetchedAt()
+            );
+        }
+
+        public static List<RateResponse> from(List<ExchangeRateSnapshot> snapshots) {
+            return snapshots.stream()
+                    .map(RateResponse::from)
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/interfaces/ExchangeRateV1ApiSpec.java
+++ b/src/main/java/com/lemonpay/exchange/interfaces/ExchangeRateV1ApiSpec.java
@@ -1,0 +1,31 @@
+package com.lemonpay.exchange.interfaces;
+
+import com.lemonpay.common.interfaces.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import java.util.List;
+
+@Tag(name = "ExchangeRate V1 API Specification")
+public interface ExchangeRateV1ApiSpec {
+
+    @GetMapping(value = "/latest", params = {"baseCurrency", "targetCurrency"})
+    @Operation(
+            summary = "Base/Target 환율 정보 단건 조회 API",
+            description = "Base/Target 환율 정보를 단건 조회 후 응답합니다."
+    )
+    ResponseEntity<ApiResponse<ExchangeRateDto.RateResponse>> getLatestCurrencyRate(
+            @Valid @ModelAttribute ExchangeRateDto.RateRequest request
+    );
+
+    @GetMapping
+    @Operation(
+            summary = "Base/Target 환율 정보 다건 조회 API",
+            description = "현재 제공하는 Base/Target 환율 정보 목록을 조회하여 다건 응답합니다."
+    )
+    ResponseEntity<ApiResponse<List<ExchangeRateDto.RateResponse>>> getLatestCurrencyRates();
+}

--- a/src/main/java/com/lemonpay/exchange/interfaces/ExchangeRateV1Controller.java
+++ b/src/main/java/com/lemonpay/exchange/interfaces/ExchangeRateV1Controller.java
@@ -1,0 +1,42 @@
+package com.lemonpay.exchange.interfaces;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.interfaces.ApiResponse;
+import com.lemonpay.exchange.application.ExchangeRateQueryService;
+import com.lemonpay.exchange.application.ExchangeRateSnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/exchange-rates")
+@RequiredArgsConstructor
+public class ExchangeRateV1Controller implements ExchangeRateV1ApiSpec {
+
+    private final ExchangeRateQueryService queryService;
+
+    @Override
+    public ResponseEntity<ApiResponse<ExchangeRateDto.RateResponse>> getLatestCurrencyRate(
+            ExchangeRateDto.RateRequest request) {
+        Currency baseCurrency = Currency.valueOf(request.baseCurrency().toUpperCase());
+        Currency targetCurrency = Currency.valueOf(request.targetCurrency().toUpperCase());
+        ExchangeRateSnapshot result = queryService.getLatestExchangeRate(baseCurrency, targetCurrency);
+        return ResponseEntity.ok(
+                ApiResponse.of(ExchangeRateDto.RateResponse.from(result))
+        );
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<List<ExchangeRateDto.RateResponse>>> getLatestCurrencyRates() {
+        List<ExchangeRateSnapshot> list = queryService.getLatestExchangeRates();
+        return ResponseEntity.ok(
+                ApiResponse.of(ExchangeRateDto.RateResponse.from(list))
+        );
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,3 +25,13 @@ springdoc:
     path: /swagger-ui.html
     operations-sorter: method
     tags-sorter: alpha
+
+# dev override: 개발 서버에서는 외부 API provider와 자동 스케줄링을 활성화합니다.
+exchange:
+  rate:
+    provider: ${EXCHANGE_RATE_PROVIDER:api} # stub | api
+    scheduler:
+      enabled: true
+  rate-api:
+    base-url: ${EXCHANGE_RATE_API_URL:https://v6.exchangerate-api.com}
+    api-key: ${EXCHANGE_RATE_API_KEY:}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -41,10 +41,12 @@ springdoc:
     operations-sorter: method
     tags-sorter: alpha
 
-### 환율 fetch 설정 ###
+# local override: 로컬 개발에서는 자동 스케줄링을 비활성화합니다.
 exchange:
   rate:
-    provider: stub # stub | api
+    provider: ${EXCHANGE_RATE_PROVIDER:stub}
+    scheduler:
+      enabled: false
   rate-api:
     base-url: ${EXCHANGE_RATE_API_URL:https://v6.exchangerate-api.com}
     api-key: ${EXCHANGE_RATE_API_KEY:}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -40,3 +40,11 @@ springdoc:
     path: /swagger-ui.html
     operations-sorter: method
     tags-sorter: alpha
+
+### 환율 fetch 설정 ###
+exchange:
+  rate:
+    provider: stub # stub | api
+  rate-api:
+    base-url: ${EXCHANGE_RATE_API_URL:https://v6.exchangerate-api.com}
+    api-key: ${EXCHANGE_RATE_API_KEY:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,16 @@ spring:
 springdoc:
   api-docs:
     enabled: false
+
+### Exchange rate defaults ###
+exchange:
+  rate:
+    sync-ttl-minutes: 60
+    scheduler:
+      cron: "0 */10 * * * *"
+      pairs:
+        - USD/KRW
+        - JPY/KRW
+  rate-api:
+    base-url: ${EXCHANGE_RATE_API_URL}
+    api-key: ${EXCHANGE_RATE_API_KEY}

--- a/src/test/java/com/lemonpay/exchange/application/ExchangeRateApiIntegrationTest.java
+++ b/src/test/java/com/lemonpay/exchange/application/ExchangeRateApiIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.*;
+import com.lemonpay.exchange.infrastructure.provider.exchangeapi.ExchangeRateApiProperties;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("local")
+@SpringBootTest(properties = {
+        "exchange.rate.provider=api"
+})
+@Transactional
+public class ExchangeRateApiIntegrationTest {
+
+    @Autowired
+    private ExchangeRateSyncUseCase useCase;
+
+    @Autowired
+    private ExchangeRateRepository exchangeRateRepository;
+
+    @Autowired
+    private ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+    @Autowired
+    private ExchangeRateApiProperties exchangeRateApiProperties;
+
+
+    @Test
+    @DisplayName("API key가 있으면 실제 API 환율을 조회해 history 내역과 master 원장에 저장한다.")
+    void syncWithApiProvider_success() {
+        // skip
+        Assumptions.assumeTrue(exchangeRateApiProperties.hasApiKey(),
+                "외부API_exchangerate-api.com 에 대한 API_KEY가 없어 통합테스트 스킵합니다.");
+
+        // given & when
+        ExchangeRateSnapshot snapshot = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+
+        // then
+        ExchangeRate master = exchangeRateRepository.findByCurrencyPair(Currency.USD, Currency.KRW)
+                .orElseThrow();
+        ExchangeRateHistory history = exchangeRateHistoryRepository.findLatestOfficial(Currency.USD, Currency.KRW)
+                .orElseThrow();
+
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.baseCurrency()).isEqualTo(Currency.USD);
+        assertThat(snapshot.rate()).isPositive();
+        assertThat(snapshot.source()).isEqualTo(ExchangeRateSource.API);
+        assertThat(snapshot.rateType()).isEqualTo(ExchangeRateType.OFFICIAL);
+
+
+        assertThat(master.getRate()).isEqualByComparingTo(snapshot.rate());
+        assertThat(master.getRateType()).isEqualTo(ExchangeRateType.OFFICIAL);
+        assertThat(master.getSource()).isEqualTo(ExchangeRateSource.API);
+
+        assertThat(history.getRate()).isEqualByComparingTo(snapshot.rate());
+        assertThat(history.getRateType()).isEqualTo(ExchangeRateType.OFFICIAL);
+        assertThat(history.getSource()).isEqualTo(ExchangeRateSource.API);
+    }
+
+}

--- a/src/test/java/com/lemonpay/exchange/application/ExchangeRateApiIntegrationTest.java
+++ b/src/test/java/com/lemonpay/exchange/application/ExchangeRateApiIntegrationTest.java
@@ -9,13 +9,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 
 @ActiveProfiles("local")
 @SpringBootTest(properties = {
-        "exchange.rate.provider=api"
+        "exchange.rate.provider=api",
+        "exchange.rate.sync-ttl-minutes=60",
+        "exchange.rate.scheduler.enabled=false"
 })
 @Transactional
 public class ExchangeRateApiIntegrationTest {
@@ -30,6 +37,9 @@ public class ExchangeRateApiIntegrationTest {
     private ExchangeRateHistoryRepository exchangeRateHistoryRepository;
     @Autowired
     private ExchangeRateApiProperties exchangeRateApiProperties;
+
+    @MockitoSpyBean
+    private ExchangeRateProvider exchangeRateProvider;
 
 
     @Test
@@ -62,6 +72,26 @@ public class ExchangeRateApiIntegrationTest {
         assertThat(history.getRate()).isEqualByComparingTo(snapshot.rate());
         assertThat(history.getRateType()).isEqualTo(ExchangeRateType.OFFICIAL);
         assertThat(history.getSource()).isEqualTo(ExchangeRateSource.API);
+    }
+
+    @Test
+    @DisplayName("저장된 환율이 TTL 이내면 실제 API를 다시 호출하지 않고 동기화를 skip한다.")
+    void syncIfStale_whenFreshRateExists_skipApiCall() {
+        // skip
+        Assumptions.assumeTrue(exchangeRateApiProperties.hasApiKey(),
+                "외부API_exchangerate-api.com 에 대한 API_KEY가 없어 통합테스트 스킵합니다.");
+
+        // given
+        ExchangeRateSnapshot synced = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+        reset(exchangeRateProvider);
+
+        // when
+        ExchangeRateSyncResult result = useCase.syncIfStale(Currency.USD, Currency.KRW);
+
+        // then
+        assertThat(result.status()).isEqualTo(ExchangeRateSyncStatus.SKIPPED);
+        assertThat(result.snapshot().rate()).isEqualByComparingTo(synced.rate());
+        verify(exchangeRateProvider, never()).fetch(any(), any(), any());
     }
 
 }

--- a/src/test/java/com/lemonpay/exchange/application/ExchangeRateSnapshotTest.java
+++ b/src/test/java/com/lemonpay/exchange/application/ExchangeRateSnapshotTest.java
@@ -1,0 +1,91 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.ExchangeRate;
+import com.lemonpay.exchange.domain.ExchangeRateHistory;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ExchangeRateSnapshotTest {
+
+    private static final LocalDate RATE_DATE = LocalDate.of(2026, 6, 8);
+    private static final LocalDateTime FETCHED_AT = LocalDateTime.of(2026, 6, 8, 9, 0);
+
+    @Test
+    @DisplayName("스냅샷을 환율 마스터 엔티티로 변환한다.")
+    void toExchangeRate_success() {
+        // given
+        ExchangeRateSnapshot snapshot = createOfficialSnapshot();
+
+        // when
+        ExchangeRate exchangeRate = snapshot.toExchangeRate();
+
+        // then
+        assertThat(exchangeRate.getBaseCurrency()).isEqualTo(Currency.USD);
+        assertThat(exchangeRate.getTargetCurrency()).isEqualTo(Currency.KRW);
+        assertThat(exchangeRate.getRate()).isEqualByComparingTo("1350.00000000");
+        assertThat(exchangeRate.getRateType()).isEqualTo(ExchangeRateType.OFFICIAL);
+        assertThat(exchangeRate.getSource()).isEqualTo(ExchangeRateSource.API);
+    }
+
+    @Test
+    @DisplayName("공식 환율 스냅샷을 공식 환율 이력으로 변환한다.")
+    void toOfficialHistory_success() {
+        // given
+        ExchangeRateSnapshot snapshot = createOfficialSnapshot();
+
+        // when
+        ExchangeRateHistory history = snapshot.toOfficialHistory();
+
+        // then
+        assertThat(history.getBaseCurrency()).isEqualTo(Currency.USD);
+        assertThat(history.getTargetCurrency()).isEqualTo(Currency.KRW);
+        assertThat(history.getRate()).isEqualByComparingTo("1350.00000000");
+        assertThat(history.getRateType()).isEqualTo(ExchangeRateType.OFFICIAL);
+        assertThat(history.getSource()).isEqualTo(ExchangeRateSource.API);
+        assertThat(history.getSourceHistoryId()).isNull();
+    }
+
+    @Test
+    @DisplayName("가환율 스냅샷은 공식 환율 이력으로 변환할 수 없다.")
+    void provisionalSnapshotToOfficialHistory_throwsException() {
+        // given
+        ExchangeRateSnapshot snapshot = new ExchangeRateSnapshot(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1350.00000000"),
+                RATE_DATE,
+                1,
+                ExchangeRateType.PROVISIONAL,
+                ExchangeRateSource.DB_FALLBACK,
+                FETCHED_AT
+        );
+
+        // when & then
+        assertThatThrownBy(snapshot::toOfficialHistory)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("공식 환율");
+    }
+
+    private ExchangeRateSnapshot createOfficialSnapshot() {
+        return new ExchangeRateSnapshot(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1350.00000000"),
+                RATE_DATE,
+                1,
+                ExchangeRateType.OFFICIAL,
+                ExchangeRateSource.API,
+                FETCHED_AT
+        );
+    }
+}

--- a/src/test/java/com/lemonpay/exchange/application/ExchangeRateStubIntegrationTest.java
+++ b/src/test/java/com/lemonpay/exchange/application/ExchangeRateStubIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.ExchangeRate;
+import com.lemonpay.exchange.domain.ExchangeRateHistory;
+import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
+import com.lemonpay.exchange.domain.ExchangeRateRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "exchange.rate.provider=stub"
+})
+@Transactional
+public class ExchangeRateStubIntegrationTest {
+
+    @Autowired
+    private ExchangeRateSyncUseCase useCase;
+
+    @Autowired
+    private ExchangeRateRepository exchangeRateRepository;
+
+    @Autowired
+    private ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+
+
+    @Test
+    @DisplayName("stub provider로 환율을 동기화하면 history 내역은 저장되고 master 원장은 upsert된다.")
+    void syncWithStubProvider_success() {
+        // given & when
+        String expectedUsdToKrw = "1350.00000000";
+        ExchangeRateSnapshot snapshot = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+
+        // then
+        assertThat(snapshot.rate()).isEqualByComparingTo(expectedUsdToKrw);
+        ExchangeRate master = exchangeRateRepository.findByCurrencyPair(Currency.USD, Currency.KRW)
+                .orElseThrow();
+        assertThat(master.getRate()).isEqualByComparingTo(expectedUsdToKrw);
+
+        ExchangeRateHistory history = exchangeRateHistoryRepository.findLatestOfficial(Currency.USD, Currency.KRW)
+                .orElseThrow();
+
+        assertThat(history.getRate()).isEqualByComparingTo(expectedUsdToKrw);
+    }
+
+
+}

--- a/src/test/java/com/lemonpay/exchange/domain/ExchangeRateTest.java
+++ b/src/test/java/com/lemonpay/exchange/domain/ExchangeRateTest.java
@@ -1,6 +1,7 @@
 package com.lemonpay.exchange.domain;
 
 import com.lemonpay.common.domain.Currency;
+import com.lemonpay.common.domain.Money;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -123,6 +124,95 @@ class ExchangeRateTest {
             assertThat(exchangeRate.getRateType()).isEqualTo(ExchangeRateType.PROVISIONAL);
             assertThat(exchangeRate.getSource()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
             assertThat(exchangeRate.getFetchedAt()).isEqualTo(nextFetchedAt);
+        }
+    }
+
+    @Nested
+    @DisplayName("환율 변환 테스트")
+    class Convert {
+
+        @Test
+        @DisplayName("USD/KRW 환율로 KRW를 USD로 변환한다.")
+        void convertKrwToUsd_success() {
+            // given
+            ExchangeRate usdKrwRate = ExchangeRate.create(
+                    Currency.USD,
+                    Currency.KRW,
+                    new BigDecimal("1350.00000000"),
+                    RATE_DATE,
+                    1,
+                    ExchangeRateType.OFFICIAL,
+                    ExchangeRateSource.API,
+                    FETCHED_AT
+            );
+            Money krw = Money.won(135_000);
+
+            // when
+            Money usd = usdKrwRate.convertTargetToBase(krw);
+
+            // then
+            assertThat(usd.currency()).isEqualTo(Currency.USD);
+            assertThat(usd.amount()).isEqualByComparingTo("100.00");
+        }
+
+        @Test
+        @DisplayName("JPY/KRW 환율로 KRW를 JPY로 변환한다.")
+        void convertKrwToJpy_success() {
+            // given
+            ExchangeRate jpyKrwRate = ExchangeRate.create(
+                    Currency.JPY,
+                    Currency.KRW,
+                    new BigDecimal("9.20000000"),
+                    RATE_DATE,
+                    1,
+                    ExchangeRateType.OFFICIAL,
+                    ExchangeRateSource.API,
+                    FETCHED_AT
+            );
+            Money krw = Money.won(9_200);
+
+            // when
+            Money jpy = jpyKrwRate.convertTargetToBase(krw);
+
+            // then
+            assertThat(jpy.currency()).isEqualTo(Currency.JPY);
+            assertThat(jpy.amount()).isEqualByComparingTo("1000");
+        }
+
+        @Test
+        @DisplayName("USD/KRW 환율로 USD를 KRW로 변환한다.")
+        void convertUsdToKrw_success() {
+            // given
+            ExchangeRate usdKrwRate = ExchangeRate.create(
+                    Currency.USD,
+                    Currency.KRW,
+                    new BigDecimal("1350.00000000"),
+                    RATE_DATE,
+                    1,
+                    ExchangeRateType.OFFICIAL,
+                    ExchangeRateSource.API,
+                    FETCHED_AT
+            );
+            Money usd = Money.usd("100.00");
+
+            // when
+            Money krw = usdKrwRate.convertBaseToTarget(usd);
+
+            // then
+            assertThat(krw.currency()).isEqualTo(Currency.KRW);
+            assertThat(krw.amount()).isEqualByComparingTo("135000");
+        }
+
+        @Test
+        @DisplayName("환율 대상 통화와 다른 금액은 역방향 변환할 수 없다.")
+        void convertTargetToBaseWithDifferentCurrency_throwsException() {
+            // given
+            ExchangeRate usdKrwRate = createUsdKrwRate();
+
+            // when & then
+            assertThatThrownBy(() -> usdKrwRate.convertTargetToBase(Money.usd("10.00")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("대상 통화");
         }
     }
 

--- a/src/test/java/com/lemonpay/exchange/infrastructure/ExchangeRateJpaRepositoryTest.java
+++ b/src/test/java/com/lemonpay/exchange/infrastructure/ExchangeRateJpaRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.lemonpay.exchange.infrastructure;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.ExchangeRate;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@DataJpaTest
+class ExchangeRateJpaRepositoryTest {
+
+    private static final LocalDate RATE_DATE = LocalDate.of(2026, 6, 9);
+    private static final LocalDateTime FETCHED_AT = LocalDateTime.of(2026, 6, 9, 9, 0);
+
+    @Autowired
+    private ExchangeRateJpaRepository exchangeRateJpaRepository;
+
+    @Test
+    @DisplayName("id 없는 새 엔티티를 같은 통화쌍으로 save하면 INSERT가 발생해 unique 제약에 걸린다.")
+    void saveNewEntityWithSameCurrencyPair_throwsUniqueConstraintException() {
+        // given
+        exchangeRateJpaRepository.saveAndFlush(createUsdKrwRate("1350.00000000"));
+        ExchangeRate duplicatedCurrencyPair = createUsdKrwRate("1360.00000000");
+
+        // when & then
+        assertThatThrownBy(() -> exchangeRateJpaRepository.saveAndFlush(duplicatedCurrencyPair))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("조회한 기존 엔티티를 변경한 뒤 save하면 같은 row가 UPDATE된다.")
+    void saveManagedEntity_updatesExistingRow() {
+        // given
+        exchangeRateJpaRepository.saveAndFlush(createUsdKrwRate("1350.00000000"));
+        ExchangeRate found = exchangeRateJpaRepository
+                .findByBaseCurrencyAndTargetCurrency(Currency.USD, Currency.KRW)
+                .orElseThrow();
+
+        // when
+        found.update(
+                new BigDecimal("1360.00000000"),
+                RATE_DATE.plusDays(1),
+                2,
+                ExchangeRateType.OFFICIAL,
+                ExchangeRateSource.API,
+                FETCHED_AT.plusDays(1)
+        );
+        exchangeRateJpaRepository.saveAndFlush(found);
+
+        // then
+        ExchangeRate updated = exchangeRateJpaRepository
+                .findByBaseCurrencyAndTargetCurrency(Currency.USD, Currency.KRW)
+                .orElseThrow();
+
+        assertThat(exchangeRateJpaRepository.count()).isEqualTo(1);
+        assertThat(updated.getRate()).isEqualByComparingTo("1360.00000000");
+        assertThat(updated.getRateDate()).isEqualTo(RATE_DATE.plusDays(1));
+        assertThat(updated.getRoundNo()).isEqualTo(2);
+    }
+
+    private ExchangeRate createUsdKrwRate(String rate) {
+        return ExchangeRate.create(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal(rate),
+                RATE_DATE,
+                1,
+                ExchangeRateType.OFFICIAL,
+                ExchangeRateSource.API,
+                FETCHED_AT
+        );
+    }
+
+}

--- a/src/test/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateSchedulerTest.java
+++ b/src/test/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateSchedulerTest.java
@@ -1,0 +1,65 @@
+package com.lemonpay.exchange.infrastructure.scheduler;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.application.ExchangeRateSnapshot;
+import com.lemonpay.exchange.application.ExchangeRateSyncResult;
+import com.lemonpay.exchange.application.ExchangeRateSyncUseCase;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+import com.lemonpay.exchange.infrastructure.config.ExchangeRateSchedulerProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ExchangeRateSchedulerTest {
+
+    @Mock
+    private ExchangeRateSyncUseCase syncUseCase;
+
+    @Test
+    @DisplayName("설정된 통화쌍마다 조건부 환율 동기화를 호출한다.")
+    void syncExchangeRate_callUseCaseForEachPair() {
+        ExchangeRateSchedulerProperties properties =
+                new ExchangeRateSchedulerProperties(
+                        true,
+                        "0 */10 * * * *",
+                        List.of("USD/KRW", "JPY/KRW")
+                );
+
+        given(syncUseCase.syncIfStale(any(), any()))
+                .willReturn(ExchangeRateSyncResult.synced(mockSnapshot()));
+
+        ExchangeRateScheduler scheduler = new ExchangeRateScheduler(properties, syncUseCase);
+
+        scheduler.syncExchangeRate();
+
+        verify(syncUseCase).syncIfStale(Currency.USD, Currency.KRW);
+        verify(syncUseCase).syncIfStale(Currency.JPY, Currency.KRW);
+
+    }
+
+    private ExchangeRateSnapshot mockSnapshot() {
+        return new ExchangeRateSnapshot(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1350.00000000"),
+                LocalDate.now(),
+                1,
+                ExchangeRateType.OFFICIAL,
+                ExchangeRateSource.API,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,15 @@
+
+# test defaults: 테스트는 외부 API와 스케줄러에 의존하지 않습니다.
+exchange:
+  rate:
+    provider: stub
+    sync-ttl-minutes: 60
+    scheduler:
+      enabled: false
+      cron: "0 */10 * * * *"
+      pairs:
+        - USD/KRW
+        - JPY/KRW
+  rate-api:
+    base-url: ${EXCHANGE_RATE_API_URL:https://v6.exchangerate-api.com}
+    api-key: ${EXCHANGE_RATE_API_KEY:}


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
- 환율 정보를 외부 Provider 또는 Stub Provider로 동기화하고, 최신 환율을 조회할 수 있는 기본 기능을 구현
- 환율 조건부 동기화, TTL 정책, dev 스케줄러까지 포함해  외부 API 호출을 최소화하는 흐름을 구현

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
  - 외부 환율 Provider 인터페이스 및 Stub/API Adapter 구현
  - 환율 동기화 UseCase 추가
  - 최신 환율 단건/목록 조회 API 추가
  - TTL 기반 조건부 동기화 정책 추가
  - dev 환경 환율 동기화 스케줄러 추가
  - profile별 환율 설정 분리

## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->
- 조회 API와 동기화 UseCase를 분리해 조회는 DB master만 참조하도록 구성
- 외부 API 직접 의존을 줄이기 위해 `ExchangeRateProvider` Port를 두고 Stub/API Adapter를 교체 가능하게 구성
- TTL 이내의 최신 환율은 외부 Provider 호출 없이 skip하여 API 호출 비용을 줄임
- 운영 안전성을 위해 공통 설정에는 위험한 provider 기본값을 두지 않고, local/test에서만 stub을 명시

설계 문서:
  - [환율 Provider 클래스 다이어그램](https://github.com/junoade/lemonpay-backend/blob/dev/docs/classDiagram/01-ExchangeProvider.mermaid)
  - [환율 조건부 동기화 클래스 다이어그램](https://github.com/junoade/lemonpay-backend/blob/dev/docs/classDiagram/02-ExchangeRateConditionalSync.mermaid)
  - [환율 동기화 시퀀스 다이어그램](https://github.com/junoade/lemonpay-backend/blob/dev/docs/sequenceDiagrams/03-ExchangeRateSyncUsecase.mermaid)

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- [ ] 신규 테이블: 없음
- [ ] 컬럼 변경: 없음
- [ ] 인덱스 추가: 없음
- [ ] 마이그레이션 스크립트 포함 여부: 없음

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- [x] 신규 엔드포인트:
  - `GET /api/v1/exchange-rates`
  - `GET /api/v1/exchange-rates/latest?baseCurrency=USD&targetCurrency=KRW`
- [x] Request/Response 변경: ExchangeRateDto.RateRequest`, `ExchangeRateDto.RateResponse` 추가
- [x] 하위 호환성: 유지

## 테스트
- [x] 단위 테스트 추가/수정
- [x] 통합 테스트 추가/수정
- [x] 수동 테스트 완료 (시나리오: Swagger에서 최신 환율 단건/목록 조회, stub/api 동기화 및 스케줄링 실행 확인)

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과
- [x] 금액 연산에 BigDecimal 사용 (double/float 사용 없음)
- [x] 새 엔티티에 적절한 인덱스 설정
- [x] 민감 정보 로깅 없음 (계좌번호, 잔액 등)
- [x] API 응답에 내부 구현 노출 없음 (Entity 직접 반환 금지)

## 관련 이슈
<!-- Closes #이슈번호 -->
Refs: #46 

## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
