### PR TITLE
 fix(config): dev 컨테이너에 환율 API 환경변수 주입

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -34,6 +34,9 @@ services:
       DB_DRIVER: ${DB_DRIVER}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
+      EXCHANGE_RATE_PROVIDER: ${EXCHANGE_RATE_PROVIDER}
+      EXCHANGE_RATE_API_URL: ${EXCHANGE_RATE_API_URL}
+      EXCHANGE_RATE_API_KEY: ${EXCHANGE_RATE_API_KEY}
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
- dev app 컨테이너에 환율 API 환경변수 주입 설정 누락 조치

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
- docker compose app 환경변수에 `EXCHANGE_RATE_PROVIDER` 추가
- `EXCHANGE_RATE_API_URL`과 `EXCHANGE_RATE_API_KEY` 를 컨테이너로 전달
- dev 스케줄러 실행 시 외부 환율 API key 누락 문제 수정

## 관련 이슈
<!-- Closes #이슈번호 -->
Refs: #46 

## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
