### PR TITLE
fix(exchange): 환율 이력 회차 충돌 해결 및 계층 의존 정리

### DIFF
--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
@@ -45,6 +45,19 @@ public record ExchangeRateSnapshot(
         );
     }
 
+    public ExchangeRateSnapshot withRoundNo(int roundNo) {
+        return new ExchangeRateSnapshot(
+                baseCurrency,
+                targetCurrency,
+                rate,
+                rateDate,
+                roundNo,
+                rateType,
+                source,
+                fetchedAt
+        );
+    }
+
     public ExchangeRateHistory toOfficialHistory() {
         if (rateType != ExchangeRateType.OFFICIAL) {
             throw new IllegalStateException("공식 환율 스냅샷만 공식 환율 이력으로 변환할 수 있습니다.");

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncPolicy.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncPolicy.java
@@ -1,0 +1,24 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.exchange.domain.ExchangeRate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * 어플리케이션 레이어의 환율 동기화 TTL 정책.
+ *
+ * <p>application 계층이 infra 설정 계층 객체에 의존하지 않도록
+ * ExchangeRateConfig에서 수동 Bean으로 등록합니다.</p>
+ */
+public class ExchangeRateSyncPolicy {
+    private final Duration syncTtl;
+
+    public ExchangeRateSyncPolicy(Duration syncTtl) {
+        this.syncTtl = syncTtl;
+    }
+
+    public boolean isFresh(ExchangeRate rate, LocalDateTime now) {
+        return rate.getFetchedAt().isAfter(now.minus(syncTtl));
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
@@ -5,7 +5,6 @@ import com.lemonpay.exchange.domain.ExchangeRate;
 import com.lemonpay.exchange.domain.ExchangeRateHistory;
 import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
 import com.lemonpay.exchange.domain.ExchangeRateRepository;
-import com.lemonpay.exchange.infrastructure.config.ExchangeRateProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,14 +19,22 @@ public class ExchangeRateSyncUseCase {
     private final ExchangeRateProvider exchangeRateProvider;
     private final ExchangeRateRepository exchangeRateRepository;
     private final ExchangeRateHistoryRepository exchangeRateHistoryRepository;
-    private final ExchangeRateProperties exchangeRateProperties;
+    private final ExchangeRateSyncPolicy syncPolicy;
 
     @Transactional
     public ExchangeRateSnapshot syncExchangeRate(Currency baseCurrency, Currency targetCurrency) {
         LocalDate baseDate = LocalDate.now();
-        ExchangeRateSnapshot snapshot = exchangeRateProvider.fetch(baseCurrency, targetCurrency, baseDate);
+        ExchangeRateSnapshot fetchedSnapshot = exchangeRateProvider.fetch(baseCurrency, targetCurrency, baseDate);
 
+        int nextRoundNo = exchangeRateHistoryRepository
+                .findLatestOfficial(fetchedSnapshot.baseCurrency(), fetchedSnapshot.targetCurrency())
+                .filter(history -> history.getRateDate().isEqual(baseDate))
+                .map(history -> history.getRoundNo() + 1)
+                .orElse(1);
+
+        ExchangeRateSnapshot snapshot = fetchedSnapshot.withRoundNo(nextRoundNo);
         ExchangeRateHistory exchangeRateHistory = snapshot.toOfficialHistory();
+
         exchangeRateHistoryRepository.save(exchangeRateHistory);
         upsertExchangeRate(snapshot);
 
@@ -36,8 +43,9 @@ public class ExchangeRateSyncUseCase {
 
     @Transactional
     public ExchangeRateSyncResult syncIfStale(Currency baseCurrency, Currency targetCurrency) {
+        LocalDateTime now = LocalDateTime.now();
         return exchangeRateRepository.findByCurrencyPair(baseCurrency, targetCurrency)
-                .filter(this::isFresh)
+                .filter(rate -> syncPolicy.isFresh(rate, now))
                 .map(rate -> ExchangeRateSyncResult.skipped(
                         ExchangeRateSnapshot.from(rate),
                         "환율 정보가 TTL 이내로 skip 합니다."
@@ -63,10 +71,5 @@ public class ExchangeRateSyncUseCase {
                 ).orElseGet(snapshot::toExchangeRate);
 
         return exchangeRateRepository.save(exchangeRate);
-    }
-
-    private boolean isFresh(ExchangeRate rate) {
-        return rate.getFetchedAt()
-                .isAfter(LocalDateTime.now().minusMinutes(exchangeRateProperties.syncTtlMinutes()));
     }
 }

--- a/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateConfig.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/config/ExchangeRateConfig.java
@@ -1,10 +1,18 @@
 package com.lemonpay.exchange.infrastructure.config;
 
+import com.lemonpay.exchange.application.ExchangeRateSyncPolicy;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
 
 @Configuration
 @EnableConfigurationProperties({ExchangeRateProperties.class, ExchangeRateSchedulerProperties.class})
 public class ExchangeRateConfig {
 
+    @Bean
+    public ExchangeRateSyncPolicy exchangeRateSyncPolicy(ExchangeRateProperties exchangeRateProperties) {
+        return new ExchangeRateSyncPolicy(Duration.ofMinutes(exchangeRateProperties.syncTtlMinutes()));
+    }
 }

--- a/src/test/java/com/lemonpay/exchange/application/ExchangeRateStubIntegrationTest.java
+++ b/src/test/java/com/lemonpay/exchange/application/ExchangeRateStubIntegrationTest.java
@@ -1,17 +1,21 @@
 package com.lemonpay.exchange.application;
 
 import com.lemonpay.common.domain.Currency;
-import com.lemonpay.exchange.domain.ExchangeRate;
-import com.lemonpay.exchange.domain.ExchangeRateHistory;
-import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
-import com.lemonpay.exchange.domain.ExchangeRateRepository;
+import com.lemonpay.exchange.domain.*;
+import com.lemonpay.exchange.infrastructure.ExchangeRateHistoryJpaRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(properties = {
         "exchange.rate.provider=stub"
@@ -27,6 +31,9 @@ public class ExchangeRateStubIntegrationTest {
 
     @Autowired
     private ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+
+    @Autowired
+    private ExchangeRateHistoryJpaRepository exchangeRateHistoryJpaRepository;
 
 
     @Test
@@ -48,5 +55,59 @@ public class ExchangeRateStubIntegrationTest {
         assertThat(history.getRate()).isEqualByComparingTo(expectedUsdToKrw);
     }
 
+    @Test
+    @DisplayName("같은 통화쌍/기준일/회차의 환율 이력을 중복 저장하면 unique 제약 위반이 발생한다.")
+    void saveDuplicatedRoundHistory_throwsDataIntegrityViolationException() {
+        // given
+        LocalDate rateDate = LocalDate.now();
+        LocalDateTime fetchedAt = LocalDateTime.now();
+        ExchangeRateHistory firstRoundHistory = ExchangeRateHistory.official(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1350.00000000"),
+                rateDate,
+                1,
+                ExchangeRateSource.API,
+                fetchedAt
+        );
+        ExchangeRateHistory duplicatedRoundHistory = ExchangeRateHistory.official(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1360.00000000"),
+                rateDate,
+                1,
+                ExchangeRateSource.API,
+                fetchedAt.plusMinutes(10)
+        );
+
+        exchangeRateHistoryJpaRepository.saveAndFlush(firstRoundHistory);
+
+        // when & then
+        assertThatThrownBy(() -> exchangeRateHistoryJpaRepository.saveAndFlush(duplicatedRoundHistory))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("같은 날짜에 환율을 재동기화하면 다음 회차로 history를 누적하고 master는 최신 회차로 갱신한다.")
+    void syncExchangeRate_twiceInSameDate_incrementsRoundNo() {
+        // when
+        ExchangeRateSnapshot firstSnapshot = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+        ExchangeRateSnapshot secondSnapshot = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+
+        // then
+        assertThat(firstSnapshot.roundNo()).isEqualTo(1);
+        assertThat(secondSnapshot.roundNo()).isEqualTo(2);
+
+        ExchangeRateHistory latestHistory = exchangeRateHistoryRepository
+                .findLatestOfficial(Currency.USD, Currency.KRW)
+                .orElseThrow();
+        assertThat(latestHistory.getRoundNo()).isEqualTo(2);
+        assertThat(latestHistory.getRateDate()).isEqualTo(secondSnapshot.rateDate());
+
+        ExchangeRate master = exchangeRateRepository.findByCurrencyPair(Currency.USD, Currency.KRW)
+                .orElseThrow();
+        assertThat(master.getRoundNo()).isEqualTo(2);
+        assertThat(master.getRate()).isEqualByComparingTo(secondSnapshot.rate());
+    }
 
 }


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->
- 같은 날짜에 환율 재동기화 시 roundNo가 1로 고정되어 history unique 제약과 충돌하던 문제 수정
- ExchangeRateProperties 직접 의존을 제거해 application 계층의 infrastructure 의존 완화

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
- 기존 환율 이력 기준으로 다음 roundNo를 계산해 history를 회차별로 누적 저장
- 회차 중복 충돌 재현 테스트와 재동기화 회차 증가 테스트 추가
-  ExchangeRateSyncPolicy를 추가해 TTL 판단 정책은 applciation 레이어, 의존성 주입은 infra 계층으로 분리

## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->
- 환율 회차 정보는 application의 관심사.
- 환율 동기화 설정 값은 infra의 관심사. application은 정책만 정의. 
  - infra 레이어에서 application 정책을 주입하도록 리팩토링

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- [ ] 신규 테이블:없음
- [ ] 컬럼 변경:없음
- [ ] 인덱스 추가:없음
- [ ] 마이그레이션 스크립트 포함 여부:없음

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- [ ] 신규 엔드포인트:없음
- [ ] Request/Response 변경:없음
- [ ] 하위 호환성: 유지 / 깨짐 (깨지면 사유 기재): 유지

## 테스트
- [x] 단위 테스트 추가
- [ ] 통합 테스트 없음
- [x] 수동 테스트 완료 (시나리오: unique 제약 조건 충돌 재현 및 개선 적용 단위테스트 수행 완료)

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과
- [x] 금액 연산에 BigDecimal 사용 (double/float 사용 없음)
- [x] 새 엔티티에 적절한 인덱스 설정
- [x] 민감 정보 로깅 없음 (계좌번호, 잔액 등)
- [x] API 응답에 내부 구현 노출 없음 (Entity 직접 반환 금지)

## 관련 이슈
<!-- Closes #이슈번호 -->
Refs:#75
## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
