### PR TITLE
feat(monitoring): Actuator Prometheus 메트릭 노출 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
 	runtimeOnly("com.h2database:h2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("io.micrometer:micrometer-registry-prometheus")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
 	runtimeOnly("com.h2database:h2")

--- a/src/main/java/com/lemonpay/exchange/infrastructure/metrics/ExchangeRateMetrics.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/metrics/ExchangeRateMetrics.java
@@ -1,0 +1,70 @@
+package com.lemonpay.exchange.infrastructure.metrics;
+
+import com.lemonpay.exchange.application.ExchangeRateSnapshot;
+import com.lemonpay.exchange.application.ExchangeRateSyncResult;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExchangeRateMetrics {
+
+    private static final String SYNC_METRIC_NAME = "exchange.rate.sync";
+    private static final String SYNC_DURATION_METRIC_NAME = "exchange.rate.sync.duration";
+    private static final String PAIR_TAG = "pair";
+    private static final String STATUS_TAG = "status";
+    private static final String FAILED_STATUS = "FAILED";
+
+    private final MeterRegistry meterRegistry;
+
+    public void recordSync(ExchangeRateSyncResult result, Duration duration) {
+        try {
+            String pair = formatPair(result.snapshot());
+            String status = result.status().name();
+
+            incrementSyncCounter(pair, status);
+            recordSyncDuration(pair, status, duration);
+        } catch (Exception e) {
+            log.warn("failed to record metrics %s, caused by %s".formatted(SYNC_METRIC_NAME, e));
+        }
+    }
+
+    public void recordFailure(String pair, Duration duration) {
+        try {
+            incrementSyncCounter(pair, FAILED_STATUS);
+            recordSyncDuration(pair, FAILED_STATUS, duration);
+        } catch (Exception e) {
+            log.warn("failed to record metrics %s, caused by %s".formatted(SYNC_METRIC_NAME, e));
+        }
+
+    }
+
+    private void incrementSyncCounter(String pair, String status) {
+        Counter.builder(SYNC_METRIC_NAME)
+                .description("Exchange rate sync execution count")
+                .tag(PAIR_TAG, pair)
+                .tag(STATUS_TAG, status)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    private void recordSyncDuration(String pair, String status, Duration duration) {
+        Timer.builder(SYNC_DURATION_METRIC_NAME)
+                .description("Exchange rate sync execution duration")
+                .tag(PAIR_TAG, pair)
+                .tag(STATUS_TAG, status)
+                .register(meterRegistry)
+                .record(duration);
+    }
+
+    private String formatPair(ExchangeRateSnapshot snapshot) {
+        return "%s/%s".formatted(snapshot.baseCurrency(), snapshot.targetCurrency());
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateScheduler.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateScheduler.java
@@ -4,11 +4,14 @@ import com.lemonpay.common.domain.Currency;
 import com.lemonpay.exchange.application.ExchangeRateSyncResult;
 import com.lemonpay.exchange.application.ExchangeRateSyncUseCase;
 import com.lemonpay.exchange.infrastructure.config.ExchangeRateSchedulerProperties;
+import com.lemonpay.exchange.infrastructure.metrics.ExchangeRateMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.time.Duration;
 
 @Slf4j
 @Component
@@ -20,25 +23,39 @@ import org.springframework.stereotype.Component;
 public class ExchangeRateScheduler {
     private final ExchangeRateSchedulerProperties properties;
     private final ExchangeRateSyncUseCase syncUseCase;
+    private final ExchangeRateMetrics exchangeRateMetrics;
 
     @Scheduled(cron = "${exchange.rate.scheduler.cron}")
     public void syncExchangeRate() {
         if(!properties.enabled()) return;
 
         for(String pairStr : properties.pairs()) {
-            CurrencyPair pair = parseToCurrencyPair(pairStr);
+            long startedAt = System.nanoTime();
 
-            ExchangeRateSyncResult result = syncUseCase.syncIfStale(pair.baseCurrency, pair.targetCurrency);
+            try {
+                CurrencyPair pair = parseToCurrencyPair(pairStr);
+                ExchangeRateSyncResult result = syncUseCase.syncIfStale(pair.baseCurrency, pair.targetCurrency);
+                Duration duration = elapsedSince(startedAt);
 
-            log.info("exchange rate sync result: pair={}/{}, status={}, reason={}",
-                    pair.baseCurrency(),
-                    pair.targetCurrency(),
-                    result.status(),
-                    result.reason());
+                exchangeRateMetrics.recordSync(result, duration);
+
+                log.info("exchange rate sync result: pair={}/{}, status={}, reason={}",
+                        pair.baseCurrency(),
+                        pair.targetCurrency(),
+                        result.status(),
+                        result.reason());
+            } catch (Exception e) {
+                exchangeRateMetrics.recordFailure(pairStr, elapsedSince(startedAt));
+                log.warn("exchange rate sync failed: pair={}", pairStr, e);
+            }
         }
     }
 
     private record CurrencyPair(Currency baseCurrency, Currency targetCurrency) { }
+
+    private Duration elapsedSince(long startedAt) {
+        return Duration.ofNanos(System.nanoTime() - startedAt);
+    }
 
     private CurrencyPair parseToCurrencyPair(String pair) {
         String[] split = pair.split("/");

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,16 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
+### dev override: 운영 유사 모니터링 검증을 위해 Prometheus endpoint를 노출 ###
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: always
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -25,6 +25,17 @@ spring:
         use_sql_comments: true
         generate_statistics: true
 
+### local override: 개발 편의를 위해 Actuator 상세 health와 metrics endpoint를 노출 ###
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+
+
 logging:
   level:
     ## 검증(dev) / 운영(main)에선 주의

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,20 @@ spring:
   application:
     name: lemonpay
 
+### Do not expose env/configprops/heapdump on public networks. ###
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  endpoint:
+    health:
+      show-details: never
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
 springdoc:
   api-docs:
     enabled: false

--- a/src/test/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateSchedulerTest.java
+++ b/src/test/java/com/lemonpay/exchange/infrastructure/scheduler/ExchangeRateSchedulerTest.java
@@ -7,6 +7,7 @@ import com.lemonpay.exchange.application.ExchangeRateSyncUseCase;
 import com.lemonpay.exchange.domain.ExchangeRateSource;
 import com.lemonpay.exchange.domain.ExchangeRateType;
 import com.lemonpay.exchange.infrastructure.config.ExchangeRateSchedulerProperties;
+import com.lemonpay.exchange.infrastructure.metrics.ExchangeRateMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,12 +15,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +31,9 @@ class ExchangeRateSchedulerTest {
 
     @Mock
     private ExchangeRateSyncUseCase syncUseCase;
+
+    @Mock
+    private ExchangeRateMetrics exchangeRateMetrics;
 
     @Test
     @DisplayName("설정된 통화쌍마다 조건부 환율 동기화를 호출한다.")
@@ -38,22 +45,50 @@ class ExchangeRateSchedulerTest {
                         List.of("USD/KRW", "JPY/KRW")
                 );
 
-        given(syncUseCase.syncIfStale(any(), any()))
-                .willReturn(ExchangeRateSyncResult.synced(mockSnapshot()));
+        given(syncUseCase.syncIfStale(Currency.USD, Currency.KRW))
+                .willReturn(ExchangeRateSyncResult.synced(mockSnapshot(Currency.USD, Currency.KRW)));
+        given(syncUseCase.syncIfStale(Currency.JPY, Currency.KRW))
+                .willReturn(ExchangeRateSyncResult.synced(mockSnapshot(Currency.JPY, Currency.KRW)));
 
-        ExchangeRateScheduler scheduler = new ExchangeRateScheduler(properties, syncUseCase);
+        ExchangeRateScheduler scheduler = new ExchangeRateScheduler(properties, syncUseCase, exchangeRateMetrics);
 
         scheduler.syncExchangeRate();
 
         verify(syncUseCase).syncIfStale(Currency.USD, Currency.KRW);
         verify(syncUseCase).syncIfStale(Currency.JPY, Currency.KRW);
+        verify(exchangeRateMetrics, times(2)).recordSync(any(ExchangeRateSyncResult.class), any(Duration.class));
 
     }
 
-    private ExchangeRateSnapshot mockSnapshot() {
+    @Test
+    @DisplayName("특정 통화쌍 동기화가 실패해도 다음 통화쌍 동기화를 계속 진행한다.")
+    void syncExchangeRate_continueWhenOnePairFails() {
+        ExchangeRateSchedulerProperties properties =
+                new ExchangeRateSchedulerProperties(
+                        true,
+                        "0 */10 * * * *",
+                        List.of("USD/KRW", "JPY/KRW")
+                );
+
+        given(syncUseCase.syncIfStale(Currency.USD, Currency.KRW))
+                .willThrow(new IllegalStateException("API failure"));
+        given(syncUseCase.syncIfStale(Currency.JPY, Currency.KRW))
+                .willReturn(ExchangeRateSyncResult.synced(mockSnapshot(Currency.JPY, Currency.KRW)));
+
+        ExchangeRateScheduler scheduler = new ExchangeRateScheduler(properties, syncUseCase, exchangeRateMetrics);
+
+        scheduler.syncExchangeRate();
+
+        verify(syncUseCase).syncIfStale(Currency.USD, Currency.KRW);
+        verify(syncUseCase).syncIfStale(Currency.JPY, Currency.KRW);
+        verify(exchangeRateMetrics).recordFailure(eq("USD/KRW"), any(Duration.class));
+        verify(exchangeRateMetrics).recordSync(any(ExchangeRateSyncResult.class), any(Duration.class));
+    }
+
+    private ExchangeRateSnapshot mockSnapshot(Currency baseCurrency, Currency targetCurrency) {
         return new ExchangeRateSnapshot(
-                Currency.USD,
-                Currency.KRW,
+                baseCurrency,
+                targetCurrency,
                 new BigDecimal("1350.00000000"),
                 LocalDate.now(),
                 1,


### PR DESCRIPTION
## 개요
<!-- 이 PR이 해결하는 문제 또는 구현하는 기능을 1-2문장으로 -->

- 환율 동기화 성공 여부, 실패 빈도, 지연 시간, 애플리케이션 상태를 운영자가 확인할 수 있도록 Actuator/Prometheus 기반 모니터링을 추가함.
  - Spring Boot Actuator endpoint를 노출하고, Micrometer를 통해 환율 동기화 결과를 Prometheus가 scrape할 수 있는 metric으로 기록.

## 변경 사항
<!-- 주요 변경 내용을 bullet으로 -->
- `micrometer-registry-prometheus` 의존성 추가
- 공통 profile에서 `/actuator/health`, `/actuator/prometheus` endpoint 노출
- local/dev profile에서 health 상세 정보 확인 가능하도록 설정
- `ExchangeRateMetrics` 추가
  - 환율 동기화 결과 counter 기록
  - 환율 동기화 실행 시간 timer 기록
- `ExchangeRateScheduler`에서 통화쌍별 동기화 결과 metric 기록
- 특정 통화쌍 동기화 실패가 전체 스케줄 루프를 중단하지 않도록 예외 격리
- 스케줄러 metric 기록 및 실패 격리 테스트 추가

## 설계 결정
<!-- 왜 이렇게 구현했는지. 대안이 있었다면 왜 이 방식을 선택했는지 -->
- Actuator endpoint는 공통 profile에서 `health`, `prometheus`만 제한적으로 노출하기로 결정.
  - 운영 환경에서 내부 설정, Bean 정보, 환경변수, thread dump 등이 노출되지 않기 위함입니다.
- local/dev profile에서는 개발 및 검증 편의를 위해 health 상세 정보를 확인할 수 있도록 override
- 환율 동기화 metric은 `ExchangeRateMetrics` 컴포넌트로 분리
  - 스케줄러는 동기화 흐름을 담당하고, metric name/tag 정책은 별도 컴포넌트에 모으기 위함입니다.
- metric label은 `pair`, `status`로 제한
  - 사용자 식별자, 거래번호 등 high-cardinality 또는 민감 정보를 label에 포함하지 않기 위함입니다.
- metric 기록은 best-effort로 처리
  - metric 기록 실패가 환율 동기화 흐름에 영향을 주지 않도록 하기 위함.
- Prometheus는 각 애플리케이션 인스턴스의 `/actuator/prometheus` endpoint를 scrape하고, 
- 서버별 metric은 PromQL에서 집계하는 구조를 전제로 합니다.

## DB 변경
<!-- 테이블/컬럼 추가·변경·삭제가 있으면 기재. 없으면 "없음" -->
- [ ] 신규 테이블: 없음
- [ ] 컬럼 변경: 없음
- [ ] 인덱스 추가:없음
- [ ] 마이그레이션 스크립트 포함 여부: 없음

## API 변경
<!-- 엔드포인트 추가·변경이 있으면 기재. 없으면 "없음" -->
- [x] 신규 엔드포인트:
    - `GET /actuator/health`
    - `GET /actuator/prometheus`
  - [ ] Request/Response 변경: 없음
  - [x] 하위 호환성: 유지

## 테스트
- [x] 단위 테스트 수정 : `ExchangeRateSchedulerTest`
- [ ] 통합 테스트 없음.
- [x] 수동 테스트 완료
  - 시나리오: `/actuator/health`, `/actuator/prometheus` endpoint 응답 확인
  - 시나리오: 환율 스케줄러 실행 후 `exchange_rate_sync_total`, `exchange_rate_sync_duration_seconds` metric 노출 확인

## 체크리스트
- [x] 빌드 성공 (`./gradlew build`)
- [x] 기존 테스트 통과
- [x] 금액 연산에 BigDecimal 사용 (double/float 사용 없음)
- [x] 새 엔티티에 적절한 인덱스 설정
- [x] 민감 정보 로깅 없음 (계좌번호, 잔액 등)
- [x] API 응답에 내부 구현 노출 없음 (Entity 직접 반환 금지)

## 관련 이슈
<!-- Closes #이슈번호 -->
Closes: #83, #84
## 스크린샷 / 실행 결과
<!-- H2 콘솔 캡처, API 응답 등 -->
