### PR TITLE
chore(config): Resilience4j Circuit Breaker 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,15 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("io.micrometer:micrometer-registry-prometheus")
+
+	// resilience4j
+	implementation("io.github.resilience4j:resilience4j-spring-boot3:${project.properties["resilience4jVersion"]}")
+	implementation("io.github.resilience4j:resilience4j-micrometer:${project.properties["resilience4jVersion"]}")
+
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
 	runtimeOnly("com.h2database:h2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 ### Library versions ###
 springDocOpenApiVersion=2.8.6
+resilience4jVersion=2.3.0

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateProviderException.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateProviderException.java
@@ -1,0 +1,12 @@
+package com.lemonpay.exchange.application;
+
+public class ExchangeRateProviderException extends RuntimeException {
+
+    public ExchangeRateProviderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ExchangeRateProviderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,7 +17,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus
+        include: health,info,prometheus,circuitbreakers
   endpoint:
     health:
       show-details: always

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,7 +30,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info,metrics,prometheus,circuitbreakers
   endpoint:
     health:
       show-details: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: lemonpay
 
-### Do not expose env/configprops/heapdump on public networks. ###
+### Do not expose env/configprops/heapdump/circuitbreakers on public networks. ###
 management:
   endpoints:
     web:
@@ -15,6 +15,21 @@ management:
     metrics:
       export:
         enabled: true
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      exchangeRateApi:
+        sliding-window-type: count_based
+        sliding-window-size: 5
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 2
+        recordExceptions:
+          - com.lemonpay.exchange.application.ExchangeRateProviderException
+        ignore-exceptions:
+          - com.lemonpay.common.exception.CoreException
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 개요
- 외부 환율 API 장애 대응을 위한 Resilience4j Circuit Breaker 기반 설정을 추가함.
- 환율 API Adapter에 Circuit Breaker를 적용할 수 있도록 의존성, AOP, profile별 actuator 노출 설정을 구성함.

## 변경 사항
- Resilience4j Spring Boot/Micrometer 의존성 추가
- `@CircuitBreaker` 동작을 위한 Spring AOP 의존성 추가
- 환율 API Circuit Breaker 기본 설정 추가
- local/dev profile에서 `circuitbreakers` actuator endpoint 확인 가능하도록 설정

## 설계 결정
- Circuit Breaker 설정은 `exchange` 하위가 아니라 top-level `resilience4j` 설정으로 분리함
  - Resilience4j는 특정 도메인 설정이 아니라 외부 연동 장애 격리 인프라 설정이기 때문
- 공통 profile에서는 `circuitbreakers` endpoint를 노출하지 않았음.
  - Circuit Breaker 이름과 상태, 실패율 등 내부 운영 상태가 외부에 노출될 수 있기 때문
- local/dev profile에서만 `GET /actuator/circuitbreakers`를 노출함
  - 개발 및 검증 환경에서 Circuit Breaker 상태를 확인하기 위함임.
- Resilience4j Micrometer 의존성을 함께 추가
  - 이후 Prometheus/Grafana에서 Circuit Breaker 상태 metric을 수집할 수 있도록 하기 위함임.

  ## DB 변경
  - [ ] 신규 테이블: 없음
  - [ ] 컬럼 변경: 없음
  - [ ] 인덱스 추가: 없음
  - [ ] 마이그레이션 스크립트 포함 여부: 없음

  ## API 변경
  - [x] 신규 엔드포인트:
    - local/dev profile에서 `GET /actuator/circuitbreakers` 확인 가능
  - [ ] Request/Response 변경: 없음
  - [x] 하위 호환성: 유지

  ## 테스트
  - [ ] 단위 테스트 없음
  - [ ] 통합 테스트 없음
  - [ ] 수동 테스트 없음

  ## 체크리스트
  - [x] 빌드 성공 (`./gradlew build`)
  - [x] 기존 테스트 통과
  - [x] 금액 연산에 BigDecimal 사용 (double/float 사용 없음)
  - [x] 새 엔티티에 적절한 인덱스 설정 (해당 없음: 신규 엔티티 없음)
  - [x] 민감 정보 로깅 없음 (계좌번호, 잔액 등)
  - [x] API 응답에 내부 구현 노출 없음 (Entity 직접 반환 금지)

  ## 관련 이슈
  Refs: #34