### PR TITLE
feat(exchange): 환율 API Circuit Breaker와 DB fallback 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,15 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("io.micrometer:micrometer-registry-prometheus")
+
+	// resilience4j
+	implementation("io.github.resilience4j:resilience4j-spring-boot3:${project.properties["resilience4jVersion"]}")
+	implementation("io.github.resilience4j:resilience4j-micrometer:${project.properties["resilience4jVersion"]}")
+
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
 	runtimeOnly("com.h2database:h2")

--- a/docs/sequenceDiagrams/04-ExchangeRateSyncHappyPath.mermaid
+++ b/docs/sequenceDiagrams/04-ExchangeRateSyncHappyPath.mermaid
@@ -1,0 +1,37 @@
+sequenceDiagram
+    actor C as Client/Scheduler
+    participant U as ExchangeRateSyncUseCase
+    participant CB as CircuitBreaker Proxy
+    participant A as ExchangeRateApiAdapter
+    participant API as 외부 API
+    participant APP as ExchangeRateHistoryAppender
+    participant M as ExchangeRateRepository
+
+    C ->> U: syncExchangeRate(baseCurrency, targetCurrency)
+    U ->> U: baseDate = LocalDate.now()
+
+    U ->> CB: exchangeRateProvider.fetch(base, target, baseDate)
+    CB ->> A: fetch(base, target, baseDate)
+    A ->> API: HTTP API call
+    API -->> A: HTTP response
+    A ->> A: ExchangeRateSnapshot 변환(source=API)
+    A -->> CB: API snapshot
+    CB -->> U: API snapshot
+
+    U ->> APP: appendOfficial(apiSnapshot)
+    Note over APP: 같은 통화쌍/기준일의 최신 이력 기준으로 nextRoundNo 계산
+    APP -->> U: savedOfficialHistory
+
+    U ->> U: ExchangeRateSnapshot.from(savedOfficialHistory)
+    U ->> M: findByCurrencyPair(base, target)
+    M -->> U: Optional<ExchangeRate>
+
+    alt currentRate exists
+        U ->> U: currentRate.update(snapshot)
+    else currentRate empty
+        U ->> U: ExchangeRate.create(snapshot)
+    end
+
+    U ->> M: save(exchangeRate)
+    M -->> U: savedRate
+    U -->> C: ExchangeRateSnapshot(source=API)

--- a/docs/sequenceDiagrams/05-ExchangeRateFallbackPath.mermaid
+++ b/docs/sequenceDiagrams/05-ExchangeRateFallbackPath.mermaid
@@ -1,0 +1,52 @@
+sequenceDiagram
+    actor C as Client/Scheduler
+    participant U as ExchangeRateSyncUseCase
+    participant CB as CircuitBreaker Proxy
+    participant A as ExchangeRateApiAdapter
+    participant API as 외부 API
+    participant APP as ExchangeRateHistoryAppender
+    participant H as ExchangeRateHistoryRepository
+    participant M as ExchangeRateRepository
+
+    C ->> U: syncExchangeRate(baseCurrency, targetCurrency)
+    U ->> CB: exchangeRateProvider.fetch(base, target, baseDate)
+
+    alt CircuitBreaker CLOSED/HALF_OPEN and API failure
+        CB ->> A: fetch(base, target, baseDate)
+        A ->> API: HTTP API call
+        API -->> A: error/timeout
+        A ->> A: RestClientException -> ExchangeRateProviderException
+        A -->> CB: ExchangeRateProviderException
+        CB ->> A: fallbackProviderFailure(..., throwable)
+        A -->> CB: ExchangeRateProviderException
+        CB -->> U: ExchangeRateProviderException
+    else CircuitBreaker OPEN
+        CB ->> A: fallbackProviderFailure(..., CallNotPermittedException)
+        A -->> CB: ExchangeRateProviderException
+        CB -->> U: ExchangeRateProviderException
+    end
+
+    U ->> H: findLatestOfficial(base, target)
+    H -->> U: sourceOfficialHistory
+
+    alt sourceOfficialHistory exists
+        U ->> APP: appendDbFallback(sourceOfficialHistory)
+        Note over APP: source official history 기준으로 DB_FALLBACK 이력 생성
+        APP -->> U: savedFallbackHistory
+
+        U ->> U: ExchangeRateSnapshot.from(savedFallbackHistory)
+        U ->> M: findByCurrencyPair(base, target)
+        M -->> U: Optional<ExchangeRate>
+
+        alt currentRate exists
+            U ->> U: currentRate.update(fallbackSnapshot)
+        else currentRate empty
+            U ->> U: ExchangeRate.create(fallbackSnapshot)
+        end
+
+        U ->> M: save(exchangeRate)
+        M -->> U: savedRate
+        U -->> C: ExchangeRateSnapshot(source=DB_FALLBACK)
+    else sourceOfficialHistory empty
+        U -->> C: ExchangeRateProviderException
+    end

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 ### Library versions ###
 springDocOpenApiVersion=2.8.6
+resilience4jVersion=2.3.0

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateHistoryAppender.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateHistoryAppender.java
@@ -1,0 +1,71 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.exchange.domain.ExchangeRateHistory;
+import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeRateHistoryAppender {
+    private final ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+
+    @Transactional
+    public ExchangeRateHistory appendOfficial(ExchangeRateSnapshot snapshot) {
+        Optional<ExchangeRateHistory> latestHistory = exchangeRateHistoryRepository.findLatestByCurrencyPairAndRateDate(
+                snapshot.baseCurrency(),
+                snapshot.targetCurrency(),
+                snapshot.rateDate()
+        );
+        int nextRoundNo = nextRoundNo(latestHistory);
+        ExchangeRateHistory history = snapshot
+                .withRoundNo(nextRoundNo)
+                .toOfficialHistory();
+        return exchangeRateHistoryRepository.save(history);
+    }
+
+    /**
+     * fallback이 반복되면 source history 이력이 달라질 수 있으므로 파라미터로 넘기도록 한다.
+     * @param officialHistory
+     * @return
+     */
+    @Transactional
+    public ExchangeRateHistory appendDbFallback(ExchangeRateHistory officialHistory) {
+        /*
+         * DB_FALLBACK policy:
+         * - rateDate는 장애 발생일이 아니라 원본 official history의 기준일을 유지한다.
+         * - roundNo는 원본 rateDate의 최신 이력 기준으로 증가시킨다.
+         * - fetchedAt은 fallback 생성 시각을 기록한다.
+         * - sourceHistoryId는 fallback chain 방지를 위해 항상 원본 official history를 참조한다.
+         */
+        Optional<ExchangeRateHistory> latestHistory = exchangeRateHistoryRepository.findLatestByCurrencyPairAndRateDate(
+                officialHistory.getBaseCurrency(),
+                officialHistory.getTargetCurrency(),
+                officialHistory.getRateDate()
+        );
+        int nextRoundNo = nextRoundNo(latestHistory);
+
+        ExchangeRateHistory history = ExchangeRateHistory.fallback(
+                officialHistory.getBaseCurrency(),
+                officialHistory.getTargetCurrency(),
+                officialHistory.getRate(),
+                officialHistory.getRateDate(),
+                nextRoundNo,
+                officialHistory.getId(),
+                LocalDateTime.now()
+        );
+
+        return exchangeRateHistoryRepository.save(history);
+    }
+
+
+    private int nextRoundNo(Optional<ExchangeRateHistory> latest) {
+        return latest
+                .map(history -> history.getRoundNo() + 1)
+                .orElse(1);
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateProviderException.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateProviderException.java
@@ -1,0 +1,12 @@
+package com.lemonpay.exchange.application;
+
+public class ExchangeRateProviderException extends RuntimeException {
+
+    public ExchangeRateProviderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ExchangeRateProviderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSnapshot.java
@@ -86,4 +86,17 @@ public record ExchangeRateSnapshot(
                 exchangeRate.getFetchedAt()
         );
     }
+
+    public static ExchangeRateSnapshot from(ExchangeRateHistory history) {
+        return new ExchangeRateSnapshot(
+                history.getBaseCurrency(),
+                history.getTargetCurrency(),
+                history.getRate(),
+                history.getRateDate(),
+                history.getRoundNo(),
+                history.getRateType(),
+                history.getSource(),
+                history.getFetchedAt()
+        );
+    }
 }

--- a/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
+++ b/src/main/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCase.java
@@ -18,27 +18,26 @@ public class ExchangeRateSyncUseCase {
 
     private final ExchangeRateProvider exchangeRateProvider;
     private final ExchangeRateRepository exchangeRateRepository;
-    private final ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+    private final ExchangeRateHistoryAppender exchangeRateHistoryAppender;
     private final ExchangeRateSyncPolicy syncPolicy;
+    private final ExchangeRateHistoryRepository exchangeRateHistoryRepository;
 
     @Transactional
     public ExchangeRateSnapshot syncExchangeRate(Currency baseCurrency, Currency targetCurrency) {
         LocalDate baseDate = LocalDate.now();
-        ExchangeRateSnapshot fetchedSnapshot = exchangeRateProvider.fetch(baseCurrency, targetCurrency, baseDate);
 
-        int nextRoundNo = exchangeRateHistoryRepository
-                .findLatestOfficial(fetchedSnapshot.baseCurrency(), fetchedSnapshot.targetCurrency())
-                .filter(history -> history.getRateDate().isEqual(baseDate))
-                .map(history -> history.getRoundNo() + 1)
-                .orElse(1);
+        try {
+            ExchangeRateSnapshot fetchedSnapshot = exchangeRateProvider.fetch(baseCurrency, targetCurrency, baseDate);
 
-        ExchangeRateSnapshot snapshot = fetchedSnapshot.withRoundNo(nextRoundNo);
-        ExchangeRateHistory exchangeRateHistory = snapshot.toOfficialHistory();
-
-        exchangeRateHistoryRepository.save(exchangeRateHistory);
-        upsertExchangeRate(snapshot);
-
-        return snapshot;
+            ExchangeRateHistory savedHistory = exchangeRateHistoryAppender.appendOfficial(fetchedSnapshot);
+            return upsertMasterAndReturn(savedHistory);
+        } catch (ExchangeRateProviderException e) {
+            ExchangeRateHistory sourceOfficialHistory = exchangeRateHistoryRepository
+                    .findLatestOfficial(baseCurrency, targetCurrency)
+                    .orElseThrow(() -> e);
+            ExchangeRateHistory savedHistory = exchangeRateHistoryAppender.appendDbFallback(sourceOfficialHistory);
+            return upsertMasterAndReturn(savedHistory);
+        }
     }
 
     @Transactional
@@ -53,6 +52,12 @@ public class ExchangeRateSyncUseCase {
                 .orElseGet(() -> ExchangeRateSyncResult.synced(
                         syncExchangeRate(baseCurrency, targetCurrency)
                 ));
+    }
+
+    private ExchangeRateSnapshot upsertMasterAndReturn(ExchangeRateHistory history) {
+        ExchangeRateSnapshot snapshot = ExchangeRateSnapshot.from(history);
+        upsertExchangeRate(snapshot);
+        return snapshot;
     }
 
     private ExchangeRate upsertExchangeRate(ExchangeRateSnapshot snapshot) {

--- a/src/main/java/com/lemonpay/exchange/domain/ExchangeRateHistory.java
+++ b/src/main/java/com/lemonpay/exchange/domain/ExchangeRateHistory.java
@@ -143,6 +143,29 @@ public class ExchangeRateHistory {
         );
     }
 
+    public static ExchangeRateHistory fallback(
+            Currency baseCurrency,
+            Currency targetCurrency,
+            BigDecimal rate,
+            LocalDate rateDate,
+            int roundNo,
+            Long sourceHistoryId,
+            LocalDateTime fetchedAt
+    ) {
+        Objects.requireNonNull(sourceHistoryId, "원본 공식 환율 이력 ID는 필수입니다.");
+        return new ExchangeRateHistory(
+                baseCurrency,
+                targetCurrency,
+                rate,
+                rateDate,
+                roundNo,
+                ExchangeRateType.FALLBACK,
+                ExchangeRateSource.DB_FALLBACK,
+                sourceHistoryId,
+                fetchedAt
+        );
+    }
+
     private static void validateCurrencyPair(Currency baseCurrency, Currency targetCurrency) {
         Objects.requireNonNull(baseCurrency, "기준 통화는 필수입니다.");
         Objects.requireNonNull(targetCurrency, "대상 통화는 필수입니다.");

--- a/src/main/java/com/lemonpay/exchange/domain/ExchangeRateHistoryRepository.java
+++ b/src/main/java/com/lemonpay/exchange/domain/ExchangeRateHistoryRepository.java
@@ -2,6 +2,7 @@ package com.lemonpay.exchange.domain;
 
 import com.lemonpay.common.domain.Currency;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface ExchangeRateHistoryRepository {
@@ -11,4 +12,10 @@ public interface ExchangeRateHistoryRepository {
     Optional<ExchangeRateHistory> findById(Long id);
 
     Optional<ExchangeRateHistory> findLatestOfficial(Currency baseCurrency, Currency targetCurrency);
+
+    Optional<ExchangeRateHistory> findLatestByCurrencyPairAndRateDate(
+            Currency baseCurrency,
+            Currency targetCurrency,
+            LocalDate rateDate
+    );
 }

--- a/src/main/java/com/lemonpay/exchange/domain/ExchangeRateType.java
+++ b/src/main/java/com/lemonpay/exchange/domain/ExchangeRateType.java
@@ -2,5 +2,6 @@ package com.lemonpay.exchange.domain;
 
 public enum ExchangeRateType {
     OFFICIAL,
-    PROVISIONAL
+    PROVISIONAL,
+    FALLBACK
 }

--- a/src/main/java/com/lemonpay/exchange/infrastructure/ExchangeRateHistoryJpaRepository.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/ExchangeRateHistoryJpaRepository.java
@@ -5,6 +5,7 @@ import com.lemonpay.exchange.domain.ExchangeRateHistory;
 import com.lemonpay.exchange.domain.ExchangeRateType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface ExchangeRateHistoryJpaRepository extends JpaRepository<ExchangeRateHistory, Long> {
@@ -13,5 +14,11 @@ public interface ExchangeRateHistoryJpaRepository extends JpaRepository<Exchange
             Currency baseCurrency,
             Currency targetCurrency,
             ExchangeRateType rateType
+    );
+
+    Optional<ExchangeRateHistory> findFirstByBaseCurrencyAndTargetCurrencyAndRateDateOrderByRoundNoDesc(
+            Currency baseCurrency,
+            Currency targetCurrency,
+            LocalDate rateDate
     );
 }

--- a/src/main/java/com/lemonpay/exchange/infrastructure/ExchangeRateHistoryRepositoryImpl.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/ExchangeRateHistoryRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.lemonpay.exchange.domain.ExchangeRateType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Component
@@ -31,6 +32,19 @@ public class ExchangeRateHistoryRepositoryImpl implements ExchangeRateHistoryRep
                 baseCurrency,
                 targetCurrency,
                 ExchangeRateType.OFFICIAL
+        );
+    }
+
+    @Override
+    public Optional<ExchangeRateHistory> findLatestByCurrencyPairAndRateDate(
+            Currency baseCurrency,
+            Currency targetCurrency,
+            LocalDate rateDate
+    ) {
+        return jpaRepository.findFirstByBaseCurrencyAndTargetCurrencyAndRateDateOrderByRoundNoDesc(
+                baseCurrency,
+                targetCurrency,
+                rateDate
         );
     }
 }

--- a/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiAdapter.java
+++ b/src/main/java/com/lemonpay/exchange/infrastructure/provider/exchangeapi/ExchangeRateApiAdapter.java
@@ -4,9 +4,11 @@ import com.lemonpay.common.domain.Currency;
 import com.lemonpay.common.exception.CoreException;
 import com.lemonpay.common.exception.ErrorType;
 import com.lemonpay.exchange.application.ExchangeRateProvider;
+import com.lemonpay.exchange.application.ExchangeRateProviderException;
 import com.lemonpay.exchange.application.ExchangeRateSnapshot;
 import com.lemonpay.exchange.domain.ExchangeRateSource;
 import com.lemonpay.exchange.domain.ExchangeRateType;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,7 @@ public class ExchangeRateApiAdapter implements ExchangeRateProvider {
     private final RestClient exchangeRateRestClient;
     private final ExchangeRateApiProperties properties;
 
+    @CircuitBreaker(name = "exchangeRateApi", fallbackMethod = "fallbackProviderFailure")
     @Override
     public ExchangeRateSnapshot fetch(Currency baseCurrency, Currency targetCurrency, LocalDate rateDate) {
         if (!properties.hasApiKey()) {
@@ -62,10 +65,7 @@ public class ExchangeRateApiAdapter implements ExchangeRateProvider {
                     .retrieve()
                     .body(ExchangeRateApiResponse.class);
         } catch (RestClientException e) {
-            throw new CoreException(
-                    ErrorType.INTERNAL_SERVER_ERROR,
-                    "외부 환율 API 호출에 실패했습니다."
-            );
+            throw new ExchangeRateProviderException("외부 환율 API 호출에 실패했습니다.");
         }
     }
 
@@ -80,5 +80,20 @@ public class ExchangeRateApiAdapter implements ExchangeRateProvider {
                     "환율 API 오류 응답: %s".formatted(response.errorType())
             );
         }
+    }
+
+    private ExchangeRateSnapshot fallbackProviderFailure(Currency baseCurrency,
+                                                         Currency targetCurrency,
+                                                         LocalDate rateDate,
+                                                         Throwable throwable) {
+        if(throwable instanceof CoreException e) {
+            throw e;
+        }
+
+        if(throwable instanceof ExchangeRateProviderException e) {
+            throw e;
+        }
+        // CallNotPermittedException 등의 예외를 provider 예외로 변환.
+        throw new ExchangeRateProviderException("환율 Provider 호출에 실패했습니다 : ", throwable);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,7 +17,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus
+        include: health,info,prometheus,circuitbreakers
   endpoint:
     health:
       show-details: always

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,7 +30,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info,metrics,prometheus,circuitbreakers
   endpoint:
     health:
       show-details: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: lemonpay
 
-### Do not expose env/configprops/heapdump on public networks. ###
+### Do not expose env/configprops/heapdump/circuitbreakers on public networks. ###
 management:
   endpoints:
     web:
@@ -15,6 +15,21 @@ management:
     metrics:
       export:
         enabled: true
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      exchangeRateApi:
+        sliding-window-type: count_based
+        sliding-window-size: 5
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 2
+        recordExceptions:
+          - com.lemonpay.exchange.application.ExchangeRateProviderException
+        ignore-exceptions:
+          - com.lemonpay.common.exception.CoreException
 
 springdoc:
   api-docs:

--- a/src/test/java/com/lemonpay/exchange/application/ExchangeRateHistoryAppenderUnitTest.java
+++ b/src/test/java/com/lemonpay/exchange/application/ExchangeRateHistoryAppenderUnitTest.java
@@ -1,0 +1,168 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.ExchangeRateHistory;
+import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ExchangeRateHistoryAppenderUnitTest {
+
+    @Mock
+    private ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+
+    @InjectMocks
+    private ExchangeRateHistoryAppender appender;
+
+    @Test
+    @DisplayName("official append 시 같은 기준일의 최신 official 이력 다음 회차로 저장한다.")
+    void appendOfficialWithNextRoundNo() {
+        // given
+        LocalDate rateDate = LocalDate.now();
+        ExchangeRateHistory latestHistory = officialHistory(rateDate, 1);
+        ExchangeRateSnapshot snapshot = apiSnapshot(rateDate);
+
+        given(exchangeRateHistoryRepository.findLatestByCurrencyPairAndRateDate(
+                Currency.USD,
+                Currency.KRW,
+                rateDate
+        )).willReturn(Optional.of(latestHistory));
+        given(exchangeRateHistoryRepository.save(any(ExchangeRateHistory.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ExchangeRateHistory savedNewHistory = appender.appendOfficial(snapshot);
+
+        // then
+        assertThat(savedNewHistory.getRoundNo()).isEqualTo(2);
+        assertThat(savedNewHistory.getRateType()).isEqualTo(ExchangeRateType.OFFICIAL);
+        assertThat(savedNewHistory.getSource()).isEqualTo(ExchangeRateSource.API);
+        assertThat(savedNewHistory.getSourceHistoryId()).isNull();
+
+        verify(exchangeRateHistoryRepository).save(savedNewHistory);
+    }
+
+    @Test
+    @DisplayName("fallback append 시 원본 공식 이력 ID를 sourceHistoryId로 연결한다.")
+    void appendFallbackLinksSourceHistoryId() {
+        // given
+        LocalDate rateDate = LocalDate.now();
+        ExchangeRateHistory sourceOfficialHistory = officialHistory(rateDate, 1);
+        setId(sourceOfficialHistory, 1L);
+
+        given(exchangeRateHistoryRepository.findLatestByCurrencyPairAndRateDate(
+                Currency.USD,
+                Currency.KRW,
+                rateDate
+        )).willReturn(Optional.of(sourceOfficialHistory));
+        given(exchangeRateHistoryRepository.save(any(ExchangeRateHistory.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ExchangeRateHistory savedHistory = appender.appendDbFallback(sourceOfficialHistory);
+
+        // then
+        assertThat(savedHistory.getRoundNo()).isEqualTo(2);
+        assertThat(savedHistory.getRateType()).isEqualTo(ExchangeRateType.FALLBACK);
+        assertThat(savedHistory.getSource()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
+        assertThat(savedHistory.getSourceHistoryId()).isEqualTo(1L);
+        assertThat(savedHistory.getRate()).isEqualByComparingTo(sourceOfficialHistory.getRate());
+
+        verify(exchangeRateHistoryRepository).save(savedHistory);
+    }
+
+    @Test
+    @DisplayName("fallback이 반복되면 최신 fallback 다음 회차로 저장하되 원본 공식 이력 ID을 계속 참조한다.")
+    void repeatFallbackKeepsOfficialSourceHistoryId() {
+        // given
+        LocalDate rateDate = LocalDate.now();
+        ExchangeRateHistory sourceOfficialHistory = officialHistory(rateDate, 1);
+        setId(sourceOfficialHistory, 1L);
+
+        ExchangeRateHistory latestFallbackHistory = fallbackHistory(sourceOfficialHistory, 2);
+        setId(latestFallbackHistory, 2L);
+
+        given(exchangeRateHistoryRepository.findLatestByCurrencyPairAndRateDate(
+                Currency.USD,
+                Currency.KRW,
+                rateDate
+        )).willReturn(Optional.of(latestFallbackHistory));
+        given(exchangeRateHistoryRepository.save(any(ExchangeRateHistory.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ExchangeRateHistory savedHistory = appender.appendDbFallback(sourceOfficialHistory);
+
+        // then
+        assertThat(savedHistory.getRoundNo()).isEqualTo(3);
+        assertThat(savedHistory.getRateType()).isEqualTo(ExchangeRateType.FALLBACK);
+        assertThat(savedHistory.getSource()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
+        assertThat(savedHistory.getSourceHistoryId()).isEqualTo(sourceOfficialHistory.getId());
+        assertThat(savedHistory.getSourceHistoryId()).isNotEqualTo(latestFallbackHistory.getId());
+
+        verify(exchangeRateHistoryRepository).save(savedHistory);
+    }
+
+    private ExchangeRateSnapshot apiSnapshot(LocalDate rateDate) {
+        return new ExchangeRateSnapshot(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1350.00000000"),
+                rateDate,
+                1,
+                ExchangeRateType.OFFICIAL,
+                ExchangeRateSource.API,
+                LocalDateTime.now()
+        );
+    }
+
+    private ExchangeRateHistory officialHistory(LocalDate rateDate, int roundNo) {
+        return ExchangeRateHistory.official(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1350.00000000"),
+                rateDate,
+                roundNo,
+                ExchangeRateSource.API,
+                LocalDateTime.now()
+        );
+    }
+
+    private ExchangeRateHistory fallbackHistory(ExchangeRateHistory sourceHistory, int roundNo) {
+        return ExchangeRateHistory.fallback(
+                sourceHistory.getBaseCurrency(),
+                sourceHistory.getTargetCurrency(),
+                sourceHistory.getRate(),
+                sourceHistory.getRateDate(),
+                roundNo,
+                sourceHistory.getId(),
+                LocalDateTime.now()
+        );
+    }
+
+    /**
+     * 단위 테스트에서는 JPA id가 자동 할당되지 않으므로 sourceHistoryId 검증을 위해 id를 세팅한다.
+     * 도메인 규칙을 우회하지 않도록 남용을 주의할 것.
+     */
+    private void setId(ExchangeRateHistory history, Long id) {
+        ReflectionTestUtils.setField(history, "id", id);
+    }
+}

--- a/src/test/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCaseFallbackTest.java
+++ b/src/test/java/com/lemonpay/exchange/application/ExchangeRateSyncUseCaseFallbackTest.java
@@ -1,0 +1,136 @@
+package com.lemonpay.exchange.application;
+
+import com.lemonpay.common.domain.Currency;
+import com.lemonpay.exchange.domain.ExchangeRate;
+import com.lemonpay.exchange.domain.ExchangeRateHistory;
+import com.lemonpay.exchange.domain.ExchangeRateHistoryRepository;
+import com.lemonpay.exchange.domain.ExchangeRateRepository;
+import com.lemonpay.exchange.domain.ExchangeRateSource;
+import com.lemonpay.exchange.domain.ExchangeRateType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(properties = {
+        "exchange.rate.scheduler.enabled=false"
+})
+@Transactional
+class ExchangeRateSyncUseCaseFallbackTest {
+
+    @Autowired
+    private ExchangeRateSyncUseCase useCase;
+
+    @Autowired
+    private ExchangeRateRepository exchangeRateRepository;
+
+    @Autowired
+    private ExchangeRateHistoryRepository exchangeRateHistoryRepository;
+
+    @Test
+    @DisplayName("Provider 실패 시 최신 공식 이력을 기준으로 DB_FALLBACK 이력을 저장하고 master를 갱신한다.")
+    void fallbackWithLatestOfficialHistory() {
+        // given
+        ExchangeRateHistory officialHistory = saveOfficialHistory();
+
+        // when
+        ExchangeRateSnapshot snapshot = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+
+        // then
+        assertThat(snapshot.source()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
+        assertThat(snapshot.rateType()).isEqualTo(ExchangeRateType.FALLBACK);
+        assertThat(snapshot.roundNo()).isEqualTo(2);
+        assertThat(snapshot.rate()).isEqualByComparingTo(officialHistory.getRate());
+
+        ExchangeRateHistory latestHistory = exchangeRateHistoryRepository
+                .findLatestByCurrencyPairAndRateDate(Currency.USD, Currency.KRW, officialHistory.getRateDate())
+                .orElseThrow();
+
+        assertThat(latestHistory.getSource()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
+        assertThat(latestHistory.getRateType()).isEqualTo(ExchangeRateType.FALLBACK);
+        assertThat(latestHistory.getRoundNo()).isEqualTo(2);
+        assertThat(latestHistory.getSourceHistoryId()).isEqualTo(officialHistory.getId());
+
+        ExchangeRate master = exchangeRateRepository.findByCurrencyPair(Currency.USD, Currency.KRW)
+                .orElseThrow();
+        assertThat(master.getSource()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
+        assertThat(master.getRateType()).isEqualTo(ExchangeRateType.FALLBACK);
+        assertThat(master.getRoundNo()).isEqualTo(2);
+        assertThat(master.getRate()).isEqualByComparingTo(officialHistory.getRate());
+    }
+
+    @Test
+    @DisplayName("Provider 실패 시 기준 공식 이력이 없으면 fallback하지 않고 예외를 전파한다.")
+    void failWhenOfficialHistoryMissing() {
+        // when & then
+        assertThatThrownBy(() -> useCase.syncExchangeRate(Currency.USD, Currency.KRW))
+                .isInstanceOf(ExchangeRateProviderException.class)
+                .hasMessage("test provider failure");
+
+        assertThat(exchangeRateRepository.findByCurrencyPair(Currency.USD, Currency.KRW)).isEmpty();
+        assertThat(exchangeRateHistoryRepository.findLatestOfficial(Currency.USD, Currency.KRW)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Provider 실패가 반복되면 fallback 이력은 다음 회차로 누적되고 원본 공식 이력을 계속 참조한다.")
+    void repeatFallbackIncrementsRoundNo() {
+        // given
+        ExchangeRateHistory officialHistory = saveOfficialHistory();
+
+        // when
+        ExchangeRateSnapshot firstFallback = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+        ExchangeRateSnapshot secondFallback = useCase.syncExchangeRate(Currency.USD, Currency.KRW);
+
+        // then
+        assertThat(firstFallback.roundNo()).isEqualTo(2);
+        assertThat(secondFallback.roundNo()).isEqualTo(3);
+
+        ExchangeRateHistory latestHistory = exchangeRateHistoryRepository
+                .findLatestByCurrencyPairAndRateDate(Currency.USD, Currency.KRW, officialHistory.getRateDate())
+                .orElseThrow();
+
+        assertThat(latestHistory.getRoundNo()).isEqualTo(3);
+        assertThat(latestHistory.getSource()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
+        assertThat(latestHistory.getSourceHistoryId()).isEqualTo(officialHistory.getId());
+
+        ExchangeRate master = exchangeRateRepository.findByCurrencyPair(Currency.USD, Currency.KRW)
+                .orElseThrow();
+        assertThat(master.getRoundNo()).isEqualTo(3);
+        assertThat(master.getSource()).isEqualTo(ExchangeRateSource.DB_FALLBACK);
+    }
+
+    private ExchangeRateHistory saveOfficialHistory() {
+        return exchangeRateHistoryRepository.save(ExchangeRateHistory.official(
+                Currency.USD,
+                Currency.KRW,
+                new BigDecimal("1350.00000000"),
+                LocalDate.now(),
+                1,
+                ExchangeRateSource.API,
+                LocalDateTime.now().minusMinutes(10)
+        ));
+    }
+
+    @TestConfiguration
+    static class FailingProviderConfig {
+
+        @Bean
+        @Primary
+        ExchangeRateProvider failingExchangeRateProvider() {
+            return (baseCurrency, targetCurrency, rateDate) -> {
+                throw new ExchangeRateProviderException("test provider failure");
+            };
+        }
+    }
+}


### PR DESCRIPTION
## 개요
- 외부 환율 API 장애가 환율 동기화 전체 실패로 전파되지 않도록 Resilience4j Circuit Breaker와 DB fallback 흐름을 추가
- Provider 실패 시 최신 공식 환율 이력을 기준으로 `DB_FALLBACK` 이력을 저장
- 이 때, 어떤 공식 이력에서 파생됐는지 `sourceHistoryId`로 추적 지원

  ## 변경 사항
- Resilience4j Spring Boot/Micrometer 의존성 추가
- `@CircuitBreaker` 동작을 위한 Spring AOP 의존성 추가
- 환율 API Circuit Breaker 기본 설정 추가
- 환율 API Adapter에 Circuit Breaker 적용
  - 외부 환율 Provider 실패를 구분하기 위한 `ExchangeRateProviderException` 추가
  - CB OPEN 상태에서 발생하는 호출 차단 예외를 Provider 실패로 변환

- `ExchangeRateHistoryAppender` 추가
  - 공식 환율 이력 append
  - DB fallback 이력 append
  - 기준일별 `roundNo` 증가 처리
  - Provider 실패 시 최신 공식 환율 이력 기반 `DB_FALLBACK` history 저장
    - `sourceHistoryId`로 fallback 원본 official history 추적
- local/dev profile에서 Circuit Breaker actuator endpoint 확인 가능하도록 설정
- 정상/장애 환율 동기화 시퀀스 다이어그램 및 fallback 정책 문서 추가

## 설계 결정
- Circuit Breaker는 외부 API Adapter에 적용.
  - 외부 연동 실패 감지와 호출 차단은 infrastructure 책임으로 분류
- DB fallback 정책은 `ExchangeRateSyncUseCase`에서 처리함.
  - fallback 시 어떤 환율 이력을 저장하고 master를 갱신할지는 application orchestration 책임으로 분리.
- Adapter의 fallback method는 DB 조회를 하지 않고 예외 변환만 담당하도록 역할 분리.
  - CB OPEN 시 발생하는 호출 차단 예외를 `ExchangeRateProviderException`으로 변환해 UseCase가 동일한 fallback 흐름을 타도록 설계함.
  - `DB_FALLBACK` history도 저장 : 장애 시점에 실제로 사용한 환율을 감사 추적할 수 있어야 하기 때문.
 - fallback history의 `sourceHistoryId`는 항상 원본 official history를 참조.
    - fallback이 반복될 때 fallback -> fallback 체인이 생기지 않도록 하기 위한 목적.
- fallback history의 `rateDate`는 장애 발생일이 아니라 원본 official history의 `rateDate`를 유지합니다.
   - 실제 fallback 생성 시각은 `fetchedAt`에 기록합니다.

  ## DB 변경
  - [ ] 신규 테이블: 없음
  - [ ] 컬럼 변경: 없음
  - [ ] 인덱스 추가: 없음
  - [ ] 마이그레이션 스크립트 포함 여부: 없음

  ## API 변경
  - [x] 신규 엔드포인트:
    - local/dev profile에서 `GET /actuator/circuitbreakers` 확인 가능
  - [ ] Request/Response 변경: 없음
  - [x] 하위 호환성: 유지

  ## 테스트
- [x] 단위 테스트 추가/수정
  - `ExchangeRateHistoryAppenderUnitTest`
- [x] 통합 테스트 추가/수정
  - `ExchangeRateSyncUseCaseFallbackTest`
- [x] 수동 테스트 완료
  - 시나리오: 외부 환율 API 실패 또는 CB OPEN 상황에서 DB_FALLBACK history 저장 확인
  - 시나리오: `/actuator/circuitbreakers`에서 Circuit Breaker 상태 확인

  ## 체크리스트
  - [x] 빌드 성공 (`./gradlew build`)
  - [x] 기존 테스트 통과
  - [x] 금액 연산에 BigDecimal 사용 (double/float 사용 없음)
  - [x] 새 엔티티에 적절한 인덱스 설정 (해당 없음: 신규 엔티티 없음)
  - [x] 민감 정보 로깅 없음 (계좌번호, 잔액 등)
  - [x] API 응답에 내부 구현 노출 없음 (Entity 직접 반환 금지)

  ## 관련 이슈
  Refs: #34